### PR TITLE
Add NUnit.Runnner to required NuGet packages

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="coveralls.net" version="0.6.0" />
+  <package id="NUnit.Runners" version="2.6.4" />
   <package id="OpenCover" version="4.6.166" />
 </packages>


### PR DESCRIPTION
`NUnit.Runner` is required to run the test. Currently it'll work on AppVeyor since AppVeyor has NUnit.Runner built in.