### PR TITLE
Properly unwrap tasks returned during signup.

### DIFF
--- a/Parse/ParseUser.cs
+++ b/Parse/ParseUser.cs
@@ -167,7 +167,7 @@ namespace Parse {
           HandleSave(serverState);
         }
         return t;
-      }).OnSuccess(_ => SaveCurrentUserAsync(this)).Unwrap();
+      }).Unwrap().OnSuccess(_ => SaveCurrentUserAsync(this)).Unwrap();
     }
 
     /// <summary>


### PR DESCRIPTION
Because this task wasn't properly unwrapped, 'OnSuccess' was always being invoked, as the task was techincally successful. This caused a regression, where we always would set the current user to be this object, even if an error occured during save.

Fixes #10.

cc @hallucinogen @grantland