### PR TITLE
Parse error codes from unity using TryParse, to prevent exceptions.

### DIFF
--- a/Parse/Internal/HttpClient.Unity.cs
+++ b/Parse/Internal/HttpClient.Unity.cs
@@ -140,7 +140,11 @@ namespace Parse.Internal {
         return (HttpStatusCode)201;
       }
       String errorCode = Regex.Match(www.error, @"\d+").Value;
-      return (HttpStatusCode)Int32.Parse(errorCode);
+      int errorNumber = 0;
+      if (!Int32.TryParse(errorCode, out errorNumber)) {
+        return (HttpStatusCode)400;
+      }
+      return (HttpStatusCode)errorNumber;
     }
 
     /// <summary>


### PR DESCRIPTION
When unity has no network, it returns an empty string for 'error', which causes `Int32.Parse` to throw an exception.

Fixes #20.

cc @hallucinogen @grantland 