### PR TITLE
Fix NullReferenceException when push notification handler hasn't been registered.

### DIFF
--- a/Parse/ParsePush.WinRT.cs
+++ b/Parse/ParsePush.WinRT.cs
@@ -19,7 +19,10 @@ namespace Parse {
           PushNotificationReceived(ParseInstallation.CurrentInstallation, args);
 
           var payload = PushJson(args);
-          parsePushNotificationReceived.Invoke(ParseInstallation.CurrentInstallation, new ParsePushNotificationEventArgs(payload));
+          var handler = parsePushNotificationReceived;
+          if (handler != null) {
+            handler.Invoke(ParseInstallation.CurrentInstallation, new ParsePushNotificationEventArgs(payload));
+          }
         }
       );
     }


### PR DESCRIPTION
When a push was received without a handler, we would previously crash. This doesn't exist as an issue on other platforms, as we use other notification delivery systems there.

Fixes #27.

cc @hallucinogen @grantland 