### PR TITLE
Fix crash related to duplicate dictionary keys.

### DIFF
--- a/Parse/ParseObject.cs
+++ b/Parse/ParseObject.cs
@@ -608,7 +608,8 @@ string propertyName
       return DeepTraversal(estimatedData)
          .OfType<ParseObject>()
          .Where(o => o.ObjectId != null && o.IsDataAvailable)
-         .ToDictionary(pair => pair.ObjectId, pair => pair);
+         .GroupBy(o => o.ObjectId)
+         .ToDictionary(group => group.Key, group => group.Last());
     }
 
     internal static IDictionary<string, object> ToJSONObjectForSaving(


### PR DESCRIPTION
When saving a ParseObject which had the same object reference inside of itself twice (which is a supported use-case), we would crash because .NET's dictionary implementation does throws an exception when attempting to overwrite a key.

Fixes #29.

cc @grantland @hallucinogen 