### PR TITLE
Support custom push notification icon in Xamarin android.

### DIFF
--- a/Parse/Internal/ManifestInfo.cs
+++ b/Parse/Internal/ManifestInfo.cs
@@ -109,6 +109,19 @@ namespace Parse {
       }
     }
 
+    private static int pushIconId = -1;
+    public static int PushIconId {
+      get {
+        lock (mutex) {
+          if (pushIconId == -1) {
+            var customIcon = GetApplicationMetaData().GetInt("com.parse.push.notification_icon", -1);
+            pushIconId = customIcon == -1 ? IconId : customIcon;
+          }
+          return pushIconId;
+        }
+      }
+    }
+
     private static Intent launcherIntent;
     public static Intent LauncherIntent {
       get {

--- a/Parse/ParsePush.Android.cs
+++ b/Parse/ParsePush.Android.cs
@@ -45,7 +45,7 @@ namespace Parse {
         .SetContentTitle(new Java.Lang.String(title))
         .SetContentText(new Java.Lang.String(alert))
         .SetTicker(new Java.Lang.String(tickerText))
-        .SetSmallIcon(ManifestInfo.IconId)
+        .SetSmallIcon(ManifestInfo.PushIconId)
         .SetContentIntent(pContentIntent)
         .SetAutoCancel(true)
         .SetDefaults(NotificationDefaults.All);


### PR DESCRIPTION
This brings us up to parity with the main Parse android SDK: https://parse.com/tutorials/android-push-notifications.

Fixes #39.