### PR TITLE
Decoupled ParseObject subclassing

### DIFF
--- a/Parse/Compat/Tuple.cs
+++ b/Parse/Compat/Tuple.cs
@@ -5,6 +5,10 @@ using System.Text;
 
 namespace System {
   internal static class Tuple {
+    // This is useful because it allows for type inference, which normally cannot be done with constructors, but can be done for static methods.
+    public static Tuple<T1, T2> Create<T1, T2>(T1 t1, T2 t2) {
+      return new Tuple<T1, T2>(t1, t2);
+    }
   }
 
   internal class Tuple<T1, T2> {

--- a/Parse/Compat/Type.cs
+++ b/Parse/Compat/Type.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace System {
+  /// <summary>
+  /// Unity does not have an API for GetTypeInfo(), instead they expose most of the methods
+  /// on System.Reflection.TypeInfo on the type itself. This poses a problem for compatibility
+  /// with the rest of the C# world, as we expect the result of GetTypeInfo() to be an actual TypeInfo,
+  /// as well as be able to be converted back to a type using AsType().
+  ///
+  /// This class simply implements some of the simple missing methods on Type to make it as API-compatible
+  /// as possible to TypeInfo.
+  /// </summary>
+  internal static class TypeExtensions {
+    public static Type AsType(this Type type) {
+      return type;
+    }
+  }
+}

--- a/Parse/Internal/Object/Subclassing/IObjectSubclassingController.cs
+++ b/Parse/Internal/Object/Subclassing/IObjectSubclassingController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Parse.Internal {
+  internal interface IObjectSubclassingController {
+    String GetClassName(Type type);
+    Type GetType(String className);
+
+    bool IsTypeValid(String className, Type type);
+
+    void RegisterSubclass(Type t);
+    void UnregisterSubclass(Type t);
+
+    ParseObject Instantiate(String className);
+    IDictionary<String, String> GetPropertyMappings(String className);
+  }
+}

--- a/Parse/Internal/Object/Subclassing/ObjectSubclassInfo.cs
+++ b/Parse/Internal/Object/Subclassing/ObjectSubclassInfo.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reflection;
+
+#if UNITY
+using TypeInfo = System.Type;
+#endif
+
+namespace Parse.Internal {
+  internal class ObjectSubclassInfo {
+    public ObjectSubclassInfo(Type type, ConstructorInfo constructor) {
+      TypeInfo = type.GetTypeInfo();
+      ClassName = GetClassName(TypeInfo);
+      Constructor = constructor;
+      PropertyMappings = type.GetProperties()
+        .Select(prop => Tuple.Create(prop, prop.GetCustomAttribute<ParseFieldNameAttribute>(true)))
+        .Where(t => t.Item2 != null)
+        .Select(t => Tuple.Create(t.Item1, t.Item2.FieldName))
+        .ToDictionary(t => t.Item1.Name, t => t.Item2);
+    }
+
+    public TypeInfo TypeInfo { get; private set; }
+    public String ClassName { get; private set; }
+    public IDictionary<String, String> PropertyMappings { get; private set; }
+    private ConstructorInfo Constructor { get; set; }
+
+    public ParseObject Instantiate() {
+      return (ParseObject)Constructor.Invoke(null);
+    }
+
+    internal static String GetClassName(TypeInfo type) {
+      var attribute = type.GetCustomAttribute<ParseClassNameAttribute>();
+      return attribute != null ? attribute.ClassName : null;
+    }
+  }
+}

--- a/Parse/Internal/Object/Subclassing/ObjectSubclassingController.cs
+++ b/Parse/Internal/Object/Subclassing/ObjectSubclassingController.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+#if UNITY
+using TypeInfo = System.Type;
+#endif
+
+namespace Parse.Internal {
+  internal class ObjectSubclassingController : IObjectSubclassingController {
+    private readonly ReaderWriterLockSlim mutex;
+    private readonly IDictionary<String, ObjectSubclassInfo> registeredSubclasses;
+    private IDictionary<String, Action> registerActions;
+
+    public ObjectSubclassingController(IDictionary<Type, Action> actions) {
+      mutex = new ReaderWriterLockSlim();
+      registeredSubclasses = new Dictionary<String, ObjectSubclassInfo>();
+      registerActions = actions.ToDictionary(p => GetClassName(p.Key), p => p.Value);
+    }
+
+    public String GetClassName(Type type) {
+      return ObjectSubclassInfo.GetClassName(type.GetTypeInfo());
+    }
+
+    public Type GetType(String className) {
+      ObjectSubclassInfo info = null;
+      mutex.EnterReadLock();
+      registeredSubclasses.TryGetValue(className, out info);
+      mutex.ExitReadLock();
+
+      return info != null
+        ? info.TypeInfo.AsType()
+        : null;
+    }
+
+    public bool IsTypeValid(String className, Type type) {
+      ObjectSubclassInfo subclassInfo = null;
+
+      mutex.EnterReadLock();
+      registeredSubclasses.TryGetValue(className, out subclassInfo);
+      mutex.ExitReadLock();
+
+      return subclassInfo == null
+        ? type == typeof(ParseObject)
+        : subclassInfo.TypeInfo == type.GetTypeInfo();
+    }
+
+    public void RegisterSubclass(Type type) {
+      TypeInfo typeInfo = type.GetTypeInfo();
+      if (!typeInfo.IsSubclassOf(typeof(ParseObject))) {
+        throw new ArgumentException("Cannot register a type that is not a subclass of ParseObject");
+      }
+
+      String className = ObjectSubclassInfo.GetClassName(typeInfo);
+
+      try {
+        // Perform this as a single independent transaction, so we can never get into an
+        // intermediate state where we *theoretically* register the wrong class due to a
+        // TOCTTOU bug.
+        mutex.EnterWriteLock();
+
+        ObjectSubclassInfo previousInfo = null;
+        if (registeredSubclasses.TryGetValue(className, out previousInfo)) {
+          if (typeInfo.IsAssignableFrom(previousInfo.TypeInfo)) {
+            // Previous subclass is more specific or equal to the current type, do nothing.
+            return;
+          } else if (previousInfo.TypeInfo.IsAssignableFrom(typeInfo)) {
+            // Previous subclass is parent of new child, fallthrough and actually register
+            // this class.
+            /* Do nothing */
+          } else {
+            throw new ArgumentException(
+              "Tried to register both " + previousInfo.TypeInfo.FullName + " and " + typeInfo.FullName +
+              " as the ParseObject subclass of " + className + ". Cannot determine the right class " +
+              "to use because neither inherits from the other."
+            );
+          }
+        }
+
+        ConstructorInfo constructor = type.FindConstructor();
+        if (constructor == null) {
+          throw new ArgumentException("Cannot register a type that does not implement the default constructor!");
+        }
+
+        registeredSubclasses[className] = new ObjectSubclassInfo(type, constructor);
+      } finally {
+        mutex.ExitWriteLock();
+      }
+
+      Action toPerform = null;
+      if (registerActions.TryGetValue(className, out toPerform)) {
+        toPerform();
+      }
+    }
+
+    public void UnregisterSubclass(Type type) {
+      mutex.EnterWriteLock();
+      registeredSubclasses.Remove(GetClassName(type));
+      mutex.ExitWriteLock();
+    }
+
+    public ParseObject Instantiate(String className) {
+      ObjectSubclassInfo info = null;
+
+      mutex.EnterReadLock();
+      registeredSubclasses.TryGetValue(className, out info);
+      mutex.ExitReadLock();
+
+      return info != null
+        ? info.Instantiate()
+        : new ParseObject(className);
+    }
+
+    public IDictionary<String, String> GetPropertyMappings(String className) {
+      ObjectSubclassInfo info = null;
+      mutex.EnterReadLock();
+      registeredSubclasses.TryGetValue(className, out info);
+      mutex.ExitReadLock();
+
+      return info != null
+        ? info.PropertyMappings
+        : null;
+    }
+  }
+}

--- a/Parse/Internal/ParseCorePlugins.cs
+++ b/Parse/Internal/ParseCorePlugins.cs
@@ -29,6 +29,7 @@ namespace Parse.Internal {
     private IParseUserController userController;
     private IParsePushController pushController;
     private IParsePushChannelsController pushChannelsController;
+    private IObjectSubclassingController subclassingController;
 
     #endregion
 
@@ -240,6 +241,25 @@ namespace Parse.Internal {
       internal set {
         lock (mutex) {
           currentUserController = value;
+        }
+      }
+    }
+
+    public IObjectSubclassingController SubclassingController {
+      get {
+        lock (mutex) {
+          subclassingController = subclassingController ?? new ObjectSubclassingController(new Dictionary<Type, Action> {
+            // Do these as explicit closures instead of method references,
+            // as we should still lazy-load the controllers.
+            { typeof(ParseUser), () => CurrentUserController.ClearFromMemory() },
+            { typeof(ParseInstallation), () => CurrentInstallationController.ClearFromMemory() }
+          });
+          return subclassingController;
+        }
+      }
+      internal set {
+        lock (mutex) {
+          subclassingController = value;
         }
       }
     }

--- a/Parse/Internal/ReflectionHelpers.cs
+++ b/Parse/Internal/ReflectionHelpers.cs
@@ -51,7 +51,8 @@ namespace Parse.Internal {
 #if UNITY
       return type.GetConstructors();
 #else
-      return type.GetTypeInfo().DeclaredConstructors;
+      return type.GetTypeInfo().DeclaredConstructors
+        .Where(c => (c.Attributes & MethodAttributes.Static) == 0);
 #endif
     }
 
@@ -78,7 +79,7 @@ namespace Parse.Internal {
         let types = from p in parameters select p.ParameterType
         where types.SequenceEqual(parameterTypes)
         select constructor;
-      return constructors.Single();
+      return constructors.SingleOrDefault();
     }
 
     internal static PropertyInfo GetProperty(this Type type, string name) {

--- a/Parse/Parse.Android.csproj
+++ b/Parse/Parse.Android.csproj
@@ -73,6 +73,9 @@
     <Compile Include="Internal\Object\Controller\ParseObjectController.cs" />
     <Compile Include="Internal\Object\State\IObjectState.cs" />
     <Compile Include="Internal\Object\State\MutableObjectState.cs" />
+    <Compile Include="Internal\Object\Subclassing\IObjectSubclassingController.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassInfo.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassingController.cs" />
     <Compile Include="Internal\ParseCorePlugins.cs" />
     <Compile Include="Internal\ParseDecoder.cs" />
     <Compile Include="Internal\ParseEncoder.cs" />

--- a/Parse/Parse.Unity.csproj
+++ b/Parse/Parse.Unity.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Compat\Progress.cs" />
     <Compile Include="Compat\ThreadLocal.cs" />
     <Compile Include="Compat\Tuple.cs" />
+    <Compile Include="Compat\Type.cs" />
     <Compile Include="Internal\Analytics\Controller\IParseAnalyticsController.cs" />
     <Compile Include="Internal\Analytics\Controller\ParseAnalyticsController.cs" />
     <Compile Include="Internal\Cloud\Controller\IParseCloudCodeController.cs" />
@@ -90,6 +91,9 @@
     <Compile Include="Internal\Object\Controller\ParseObjectController.cs" />
     <Compile Include="Internal\Object\State\IObjectState.cs" />
     <Compile Include="Internal\Object\State\MutableObjectState.cs" />
+    <Compile Include="Internal\Object\Subclassing\IObjectSubclassingController.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassInfo.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassingController.cs" />
     <Compile Include="Internal\ParseAddOperation.cs" />
     <Compile Include="Internal\ParseAddUniqueOperation.cs" />
     <Compile Include="Internal\ParseCorePlugins.cs" />

--- a/Parse/Parse.csproj
+++ b/Parse/Parse.csproj
@@ -66,6 +66,9 @@
     <Compile Include="Internal\Object\Controller\ParseObjectController.cs" />
     <Compile Include="Internal\Object\State\IObjectState.cs" />
     <Compile Include="Internal\Object\State\MutableObjectState.cs" />
+    <Compile Include="Internal\Object\Subclassing\IObjectSubclassingController.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassInfo.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassingController.cs" />
     <Compile Include="Internal\ParseAddOperation.cs" />
     <Compile Include="Internal\ParseAddUniqueOperation.cs" />
     <Compile Include="Internal\Analytics\Controller\IParseAnalyticsController.cs" />

--- a/Parse/Parse.iOS.csproj
+++ b/Parse/Parse.iOS.csproj
@@ -136,6 +136,9 @@
     <Compile Include="Internal\Object\Controller\ParseObjectController.cs" />
     <Compile Include="Internal\Object\State\IObjectState.cs" />
     <Compile Include="Internal\Object\State\MutableObjectState.cs" />
+    <Compile Include="Internal\Object\Subclassing\IObjectSubclassingController.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassInfo.cs" />
+    <Compile Include="Internal\Object\Subclassing\ObjectSubclassingController.cs" />
     <Compile Include="Internal\ParseAddOperation.cs" />
     <Compile Include="Internal\ParseAddUniqueOperation.cs" />
     <Compile Include="Internal\ParseCorePlugins.cs" />

--- a/Parse/ParseObject.cs
+++ b/Parse/ParseObject.cs
@@ -28,13 +28,6 @@ namespace Parse {
   /// </remarks>
   public class ParseObject : IEnumerable<KeyValuePair<string, object>>, INotifyPropertyChanged {
     private static readonly string AutoClassName = "_Automatic";
-    private static readonly IDictionary<Tuple<Type, string>, string>
-        propertyFieldNames = new Dictionary<Tuple<Type, string>, string>();
-    private static readonly IDictionary<string, Tuple<Func<ParseObject>, Type>>
-        objectFactories = new Dictionary<string, Tuple<Func<ParseObject>, Type>>();
-    private static readonly IDictionary<Type, IDictionary<string, string>>
-      propertyMappings = new Dictionary<Type, IDictionary<string, string>>();
-    private static readonly ReaderWriterLockSlim propertyMappingsLock = new ReaderWriterLockSlim();
 
     internal readonly object mutex = new object();
 
@@ -70,6 +63,12 @@ namespace Parse {
       }
     }
 
+    internal static IObjectSubclassingController SubclassingController {
+      get {
+        return ParseCorePlugins.Instance.SubclassingController;
+      }
+    }
+
     #region ParseObject Creation
 
     /// <summary>
@@ -101,10 +100,10 @@ namespace Parse {
         throw new ArgumentException("You must specify a Parse class name when creating a new ParseObject.");
       }
       if (AutoClassName.Equals(className)) {
-        className = GetClassName(this.GetType());
+        className = SubclassingController.GetClassName(GetType());
       }
       // If this is supposed to be created by a factory but wasn't, throw an exception
-      if (this.GetType().Equals(typeof(ParseObject)) && objectFactories.ContainsKey(className)) {
+      if (!SubclassingController.IsTypeValid(className, GetType())) {
         throw new ArgumentException(
           "You must create this type of ParseObject using ParseObject.Create() or the proper subclass.");
       }
@@ -131,7 +130,7 @@ namespace Parse {
     /// <param name="className">The class of object to create.</param>
     /// <returns>A new ParseObject for the given class name.</returns>
     public static ParseObject Create(string className) {
-      return GetFactory(className)();
+      return SubclassingController.Instantiate(className);
     }
 
     /// <summary>
@@ -146,7 +145,7 @@ namespace Parse {
     public static ParseObject CreateWithoutData(string className, string objectId) {
       isCreatingPointer.Value = true;
       try {
-        var result = GetFactory(className)();
+        var result = SubclassingController.Instantiate(className);
         result.ObjectId = objectId;
         result.IsDirty = false;
         if (result.IsDirty) {
@@ -164,7 +163,7 @@ namespace Parse {
     /// </summary>
     /// <returns>A new ParseObject for the given class name.</returns>
     public static T Create<T>() where T : ParseObject {
-      return (T)Create(GetClassName(typeof(T)));
+      return (T)SubclassingController.Instantiate(SubclassingController.GetClassName(typeof(T)));
     }
 
     /// <summary>
@@ -176,7 +175,7 @@ namespace Parse {
     /// <param name="objectId">The object id for the referenced object.</param>
     /// <returns>A ParseObject without data.</returns>
     public static T CreateWithoutData<T>(string objectId) where T : ParseObject {
-      return (T)CreateWithoutData(GetClassName(typeof(T)), objectId);
+      return (T)CreateWithoutData(SubclassingController.GetClassName(typeof(T)), objectId);
     }
 
     // TODO (hallucinogen): add unit test
@@ -191,21 +190,9 @@ namespace Parse {
 
     #endregion
 
-    private static string GetFieldForPropertyName(Type type, string propertyName) {
-      var key = new Tuple<Type, string>(type, propertyName);
-      string fieldName;
-      if (propertyFieldNames.TryGetValue(key, out fieldName)) {
-        return fieldName;
-      }
-      var prop = type.GetProperty(propertyName);
-      if (prop == null) {
-        throw new ArgumentException(propertyName + " property does not exist on type " + type);
-      }
-      var attr = prop.GetCustomAttribute<ParseFieldNameAttribute>();
-      if (attr == null) {
-        throw new ArgumentException(propertyName + " does not have a ParseFieldName attribute specified.");
-      }
-      propertyFieldNames[key] = fieldName = attr.FieldName;
+    private static string GetFieldForPropertyName(String className, string propertyName) {
+      String fieldName = null;
+      SubclassingController.GetPropertyMappings(className).TryGetValue(propertyName, out fieldName);
       return fieldName;
     }
 
@@ -222,7 +209,7 @@ namespace Parse {
  string propertyName
 #endif
 ) {
-      this[GetFieldForPropertyName(GetType(), propertyName)] = value;
+      this[GetFieldForPropertyName(ClassName, propertyName)] = value;
     }
 
     /// <summary>
@@ -238,7 +225,7 @@ namespace Parse {
 string propertyName
 #endif
 ) where T : ParseObject {
-      return GetRelation<T>(GetFieldForPropertyName(GetType(), propertyName));
+      return GetRelation<T>(GetFieldForPropertyName(ClassName, propertyName));
     }
 
     /// <summary>
@@ -272,7 +259,7 @@ string propertyName
 #endif
 ) {
       T result;
-      if (TryGetValue<T>(GetFieldForPropertyName(GetType(), propertyName), out result)) {
+      if (TryGetValue<T>(GetFieldForPropertyName(ClassName, propertyName), out result)) {
         return result;
       }
       return defaultValue;
@@ -284,28 +271,6 @@ string propertyName
     internal virtual void SetDefaultValues() {
     }
 
-    internal static string GetClassName(Type t) {
-      var attr = t.GetTypeInfo().GetCustomAttribute<ParseClassNameAttribute>();
-      if (attr == null) {
-        throw new ArgumentException("No ParseClassName attribute specified on the given subclass.");
-      }
-      return attr.ClassName;
-    }
-
-    /// <summary>
-    /// Gets the appropriate factory for the given class name. If there is no factory for the class,
-    /// a factory that produces a regular ParseObject will be created.
-    /// </summary>
-    /// <param name="className">The class name for the ParseObjects the factory will create.</param>
-    /// <returns></returns>
-    private static Func<ParseObject> GetFactory(string className) {
-      Tuple<Func<ParseObject>, Type> result;
-      if (!objectFactories.TryGetValue(className, out result)) {
-        return () => new ParseObject(className);
-      }
-      return result.Item1;
-    }
-
     /// <summary>
     /// Registers a custom subclass type with the Parse SDK, enabling strong-typing of those ParseObjects whenever
     /// they appear. Subclasses must specify the ParseClassName attribute, have a default constructor, and properties
@@ -313,36 +278,11 @@ string propertyName
     /// </summary>
     /// <typeparam name="T">The ParseObject subclass type to register.</typeparam>
     public static void RegisterSubclass<T>() where T : ParseObject, new() {
-      var className = GetClassName(typeof(T));
-      if (className == null) {
-        throw new ArgumentException("No ParseClassName attribute defined for " + typeof(T));
-      }
-
-      Tuple<Func<ParseObject>, Type> oldValue;
-      if (objectFactories.TryGetValue(className, out oldValue)) {
-        if (typeof(T).GetTypeInfo().IsAssignableFrom(oldValue.Item2.GetTypeInfo())) {
-          // The old class was already more descendant than the new subclass type. No-op.
-          return;
-        }
-        if (className.Equals(GetClassName(typeof(ParseUser)))) {
-          ParseUser.ClearInMemoryUser();
-        } else if (className.Equals("_Installation")) {
-          ParseInstallation.ClearInMemoryInstallation();
-        }
-      }
-      objectFactories[className] = new Tuple<Func<ParseObject>, Type>(() => new T(), typeof(T));
+      SubclassingController.RegisterSubclass(typeof(T));
     }
 
-    internal static void UnregisterSubclass(string className) {
-      objectFactories.Remove(className);
-    }
-
-    internal static Type GetType(string className) {
-      Tuple<Func<ParseObject>, Type> result;
-      if (!objectFactories.TryGetValue(className, out result)) {
-        return typeof(ParseObject);
-      }
-      return result.Item2;
+    internal static void UnregisterSubclass<T>() where T: ParseObject, new() {
+      SubclassingController.UnregisterSubclass(typeof(T));
     }
 
     /// <summary>
@@ -1613,54 +1553,11 @@ string propertyName
       // experience anyway, especially with LINQ integration, since you'll get
       // strongly-typed queries and compile-time checking of property names and
       // types.
-      if (GetType(className) != typeof(ParseObject)) {
+      if (SubclassingController.GetType(className) != null) {
         throw new ArgumentException(
           "Use the class-specific query properties for class " + className, "className");
       }
       return new ParseQuery<ParseObject>(className);
-    }
-
-    /// <summary>
-    /// Gets the set of fieldName->propertyName mappings for the current class.
-    /// </summary>
-    internal IDictionary<string, string> PropertyMappings {
-      get {
-        IDictionary<string, string> mappings;
-        // Try to get it with only a read lock
-        propertyMappingsLock.EnterReadLock();
-        try {
-          if (propertyMappings.TryGetValue(this.GetType(), out mappings)) {
-            return mappings;
-          }
-        } finally {
-          propertyMappingsLock.ExitReadLock();
-        }
-
-        propertyMappingsLock.EnterUpgradeableReadLock();
-        try {
-          // Now that we have an upgradeable read lock, determine whether we need to
-          // upgrade. If another thread already beat us to setting this value, just
-          // move on without acquiring the write lock.
-          if (!propertyMappings.TryGetValue(this.GetType(), out mappings)) {
-            mappings = new Dictionary<string, string>();
-            foreach (var prop in this.GetType().GetProperties()) {
-              var attr = prop.GetCustomAttribute<ParseFieldNameAttribute>(true);
-              if (attr != null) {
-                mappings[attr.FieldName] = prop.Name;
-              }
-            }
-            propertyMappingsLock.EnterWriteLock();
-            try {
-              propertyMappings[this.GetType()] = mappings;
-            } finally {
-              propertyMappingsLock.ExitWriteLock();
-            }
-          }
-          return mappings;
-        } finally {
-          propertyMappingsLock.ExitUpgradeableReadLock();
-        }
-      }
     }
 
     /// <summary>
@@ -1669,13 +1566,21 @@ string propertyName
     /// properties (e.g. this happens when we recalculate all estimated data from scratch)
     /// </summary>
     protected void OnFieldsChanged(IEnumerable<string> fieldNames) {
-      var mappings = PropertyMappings;
-      fieldNames = fieldNames ?? mappings.Keys;
-      foreach (var fieldName in fieldNames) {
-        string propName;
-        if (mappings.TryGetValue(fieldName, out propName)) {
-          OnPropertyChanged(propName);
-        }
+      var mappings = SubclassingController.GetPropertyMappings(ClassName);
+      IEnumerable<String> properties;
+
+      if (fieldNames != null && mappings != null) {
+        properties = from m in mappings
+                     join f in fieldNames on m.Value equals f
+                     select m.Key;
+      } else if (mappings != null) {
+        properties = mappings.Keys;
+      } else {
+        properties = Enumerable.Empty<String>();
+      }
+
+      foreach (var property in properties) {
+        OnPropertyChanged(property);
       }
       OnPropertyChanged("Item[]");
     }

--- a/Parse/ParseQuery.cs
+++ b/Parse/ParseQuery.cs
@@ -62,6 +62,12 @@ namespace Parse {
       }
     }
 
+    internal static IObjectSubclassingController SubclassingController {
+      get {
+        return ParseCorePlugins.Instance.SubclassingController;
+      }
+    }
+
     /// <summary>
     /// Private constructor for composition of queries. A source query is required,
     /// but the remaining values can be null if they won't be changed in this
@@ -189,7 +195,7 @@ namespace Parse {
     /// Constructs a query based upon the ParseObject subclass used as the generic parameter for the ParseQuery.
     /// </summary>
     public ParseQuery()
-      : this(ParseObject.GetClassName(typeof(T))) {
+      : this(SubclassingController.GetClassName(typeof(T))) {
     }
 
     /// <summary>

--- a/ParseTest.Unit/CurrentInstallationControllerTests.cs
+++ b/ParseTest.Unit/CurrentInstallationControllerTests.cs
@@ -17,7 +17,7 @@ namespace ParseTest {
 
     [TearDown]
     public void TearDown() {
-      ParseObject.UnregisterSubclass(ParseObject.GetClassName(typeof(ParseInstallation)));
+      ParseObject.UnregisterSubclass<ParseInstallation>();
     }
 
     [Test]

--- a/ParseTest.Unit/CurrentUserControllerTests.cs
+++ b/ParseTest.Unit/CurrentUserControllerTests.cs
@@ -17,7 +17,7 @@ namespace ParseTest {
 
     [TearDown]
     public void TearDown() {
-      ParseObject.UnregisterSubclass(ParseObject.GetClassName(typeof(ParseUser)));
+      ParseObject.UnregisterSubclass<ParseUser>();
     }
 
     [Test]

--- a/ParseTest.Unit/InstallationTests.cs
+++ b/ParseTest.Unit/InstallationTests.cs
@@ -21,7 +21,7 @@ namespace ParseTest {
       ParseCorePlugins.Instance.ObjectController = null;
       ParseCorePlugins.Instance.CurrentInstallationController = null;
       ParseCorePlugins.Instance.CurrentUserController = null;
-      ParseObject.UnregisterSubclass("_Installation");
+      ParseObject.UnregisterSubclass<ParseInstallation>();
     }
 
     [Test]

--- a/ParseTest.Unit/SessionTests.cs
+++ b/ParseTest.Unit/SessionTests.cs
@@ -21,8 +21,8 @@ namespace ParseTest {
     public void TearDown() {
       ParseCorePlugins.Instance.SessionController = null;
       ParseCorePlugins.Instance.CurrentUserController = null;
-      ParseObject.UnregisterSubclass("_Session");
-      ParseObject.UnregisterSubclass("_User");
+      ParseObject.UnregisterSubclass<ParseSession>();
+      ParseObject.UnregisterSubclass<ParseUser>();
     }
 
     [Test]

--- a/ParseTest.Unit/UserTests.cs
+++ b/ParseTest.Unit/UserTests.cs
@@ -23,8 +23,8 @@ namespace ParseTest {
       ParseCorePlugins.Instance.CurrentUserController = null;
       ParseCorePlugins.Instance.SessionController = null;
       ParseCorePlugins.Instance.ObjectController = null;
-      ParseObject.UnregisterSubclass("_User");
-      ParseObject.UnregisterSubclass("_Session");
+      ParseObject.UnregisterSubclass<ParseUser>();
+      ParseObject.UnregisterSubclass<ParseSession>();
     }
 
     [Test]


### PR DESCRIPTION
Similar to the subclassing architecture used on iOS, this abstracts and cleans up all of the code relating to subclassing that currently resides inside of ParseObject.

Tests coming soon™.