### PR TITLE
Add support for redirecting class-names of ParseRelations.

### DIFF
--- a/Parse/ParseQuery.cs
+++ b/Parse/ParseQuery.cs
@@ -50,6 +50,7 @@ namespace Parse {
     private readonly ReadOnlyCollection<string> orderBy;
     private readonly ReadOnlyCollection<string> includes;
     private readonly ReadOnlyCollection<string> selectedKeys;
+    private readonly String redirectClassNameForKey;
     private readonly int? skip;
     private readonly int? limit;
 
@@ -73,7 +74,8 @@ namespace Parse {
         int? skip = null,
         int? limit = null,
         IEnumerable<string> includes = null,
-        IEnumerable<string> selectedKeys = null) {
+        IEnumerable<string> selectedKeys = null,
+        String redirectClassNameForKey = null) {
       if (source == null) {
         throw new ArgumentNullException("source");
       }
@@ -85,6 +87,7 @@ namespace Parse {
       this.limit = source.limit;
       this.includes = source.includes;
       this.selectedKeys = source.selectedKeys;
+      this.redirectClassNameForKey = source.redirectClassNameForKey;
 
       if (where != null) {
         var newWhere = MergeWhereClauses(where);
@@ -126,6 +129,10 @@ namespace Parse {
       if (selectedKeys != null) {
         var newSelectedKeys = MergeSelectedKeys(selectedKeys);
         this.selectedKeys = new ReadOnlyCollection<string>(newSelectedKeys.ToList());
+      }
+
+      if (redirectClassNameForKey != null) {
+        this.redirectClassNameForKey = redirectClassNameForKey;
       }
     }
 
@@ -324,6 +331,10 @@ namespace Parse {
     /// <returns>A new query with the additional constraint.</returns>
     public ParseQuery<T> Limit(int count) {
       return new ParseQuery<T>(this, limit: count);
+    }
+
+    internal ParseQuery<T> RedirectClassName(String key) {
+      return new ParseQuery<T>(this, redirectClassNameForKey: key);
     }
 
     #region Where
@@ -847,6 +858,9 @@ namespace Parse {
       }
       if (includeClassName) {
         result["className"] = className;
+      }
+      if (redirectClassNameForKey != null) {
+        result["redirectClassNameForKey"] = redirectClassNameForKey;
       }
       return result;
     }

--- a/Parse/ParseRelation.cs
+++ b/Parse/ParseRelation.cs
@@ -56,8 +56,14 @@ namespace Parse {
     }
 
     internal ParseQuery<T> GetQuery<T>() where T : ParseObject {
-      return new ParseQuery<T>(targetClassName)
-            .WhereRelatedTo(parent, key);
+      if (targetClassName != null) {
+        return new ParseQuery<T>(targetClassName)
+          .WhereRelatedTo(parent, key);
+      }
+
+      return new ParseQuery<T>(parent.ClassName)
+        .RedirectClassName(key)
+        .WhereRelatedTo(parent, key);
     }
 
     internal string TargetClassName {

--- a/ParseTest.Unit/ParseTest.Unit.NetFx45.csproj
+++ b/ParseTest.Unit/ParseTest.Unit.NetFx45.csproj
@@ -96,6 +96,7 @@
     <Compile Include="PushEncoderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="InstallationTests.cs" />
+    <Compile Include="RelationTests.cs" />
     <Compile Include="SessionTests.cs" />
     <Compile Include="SessionControllerTests.cs" />
     <Compile Include="ObjectControllerTests.cs" />

--- a/ParseTest.Unit/RelationTests.cs
+++ b/ParseTest.Unit/RelationTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Parse;
+using Parse.Internal;
+
+namespace ParseTest {
+  [TestFixture]
+  public class RelationTests {
+    [Test]
+    public void TestRelationQuery() {
+      ParseObject parent = ParseObject.CreateWithoutData("Foo", "abcxyz");
+
+      ParseRelation<ParseObject> relation = new ParseRelation<ParseObject>(parent, "child");
+      ParseQuery<ParseObject> query = relation.Query;
+
+      // Client side, the query will appear to be for the wrong class.
+      // When the server recieves it, the class name will be redirected using the 'redirectClassNameForKey' option.
+      Assert.AreEqual("Foo", query.ClassName);
+
+      IDictionary<string, object> encoded = query.BuildParameters();
+
+      Assert.AreEqual("child", encoded["redirectClassNameForKey"]);
+    }
+  }
+}


### PR DESCRIPTION
This is useful for creating a relation client-side when previously one did not exist.

Fixes #72.