### PR TITLE
Remove hard-coded '/1/' from all API request URIs.

### DIFF
--- a/Parse/Internal/Analytics/Controller/ParseAnalyticsController.cs
+++ b/Parse/Internal/Analytics/Controller/ParseAnalyticsController.cs
@@ -24,7 +24,7 @@ namespace Parse.Internal {
         data["dimensions"] = dimensions;
       }
 
-      var command = new ParseCommand("/1/events/" + name,
+      var command = new ParseCommand("events/" + name,
           method: "POST",
           sessionToken: sessionToken,
           data: PointerOrLocalIdEncoder.Instance.Encode(data) as IDictionary<string, object>);
@@ -42,7 +42,7 @@ namespace Parse.Internal {
         data["push_hash"] = pushHash;
       }
 
-      var command = new ParseCommand("/1/events/AppOpened",
+      var command = new ParseCommand("events/AppOpened",
           method: "POST",
           sessionToken: sessionToken,
           data: PointerOrLocalIdEncoder.Instance.Encode(data) as IDictionary<string, object>);

--- a/Parse/Internal/Cloud/Controller/ParseCloudCodeController.cs
+++ b/Parse/Internal/Cloud/Controller/ParseCloudCodeController.cs
@@ -17,7 +17,7 @@ namespace Parse.Internal {
         IDictionary<string, object> parameters,
         string sessionToken,
         CancellationToken cancellationToken) {
-      var command = new ParseCommand(string.Format("/1/functions/{0}", Uri.EscapeUriString(name)),
+      var command = new ParseCommand(string.Format("functions/{0}", Uri.EscapeUriString(name)),
           method: "POST",
           sessionToken: sessionToken,
           data: NoObjectsEncoder.Instance.Encode(parameters) as IDictionary<string, object>);

--- a/Parse/Internal/Command/ParseCommand.cs
+++ b/Parse/Internal/Command/ParseCommand.cs
@@ -13,6 +13,20 @@ namespace Parse.Internal {
   internal class ParseCommand : HttpRequest {
     private const string revocableSessionTokenTrueValue = "1";
 
+    public IDictionary<string, object> DataObject { get; private set; }
+    public override Stream Data {
+      get {
+        if (base.Data != null) {
+          return base.Data;
+        }
+
+        return base.Data = DataObject != null
+          ? new MemoryStream(Encoding.UTF8.GetBytes(Json.Encode(DataObject)))
+          : null;
+      }
+      internal set { base.Data = value; }
+    }
+
     public ParseCommand(string relativeUri,
         string method,
         string sessionToken = null,
@@ -21,8 +35,9 @@ namespace Parse.Internal {
             method: method,
             sessionToken: sessionToken,
             headers: headers,
-            stream: data != null ? new MemoryStream(UTF8Encoding.UTF8.GetBytes(Json.Encode(data))) : null,
+            stream: null,
             contentType: data != null ? "application/json" : null) {
+      DataObject = data;
     }
 
     public ParseCommand(string relativeUri,

--- a/Parse/Internal/Config/Controller/ParseConfigController.cs
+++ b/Parse/Internal/Config/Controller/ParseConfigController.cs
@@ -19,7 +19,7 @@ namespace Parse.Internal {
     public IParseCurrentConfigController CurrentConfigController { get; internal set; }
 
     public Task<ParseConfig> FetchConfigAsync(String sessionToken, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/config",
+      var command = new ParseCommand("config",
           method: "GET",
           sessionToken: sessionToken,
           data: null);

--- a/Parse/Internal/File/Controller/ParseFileController.cs
+++ b/Parse/Internal/File/Controller/ParseFileController.cs
@@ -30,7 +30,7 @@ namespace Parse.Internal {
       }
 
       var oldPosition = dataStream.Position;
-      var command = new ParseCommand("/1/files/" + state.Name,
+      var command = new ParseCommand("files/" + state.Name,
           method: "POST",
           sessionToken: sessionToken,
           contentType: state.MimeType,

--- a/Parse/Internal/HttpRequest.cs
+++ b/Parse/Internal/HttpRequest.cs
@@ -3,9 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Parse.Internal {
   /// <summary>
@@ -18,7 +15,7 @@ namespace Parse.Internal {
     /// <summary>
     /// Data stream to be uploaded.
     /// </summary>
-    public Stream Data { get; internal set; }
+    public virtual Stream Data { get; internal set; }
 
     /// <summary>
     /// HTTP method. One of <c>DELETE</c>, <c>GET</c>, <c>HEAD</c>, <c>POST</c> or <c>PUT</c>

--- a/Parse/Internal/Object/Controller/ParseObjectController.cs
+++ b/Parse/Internal/Object/Controller/ParseObjectController.cs
@@ -17,7 +17,7 @@ namespace Parse.Internal {
     public Task<IObjectState> FetchAsync(IObjectState state,
         string sessionToken,
         CancellationToken cancellationToken) {
-      var command = new ParseCommand(string.Format("/1/classes/{0}/{1}",
+      var command = new ParseCommand(string.Format("classes/{0}/{1}",
               Uri.EscapeDataString(state.ClassName),
               Uri.EscapeDataString(state.ObjectId)),
           method: "GET",
@@ -36,8 +36,8 @@ namespace Parse.Internal {
       var objectJSON = ParseObject.ToJSONObjectForSaving(operations);
 
       var command = new ParseCommand((state.ObjectId == null ?
-              string.Format("/1/classes/{0}", Uri.EscapeDataString(state.ClassName)) :
-              string.Format("/1/classes/{0}/{1}", Uri.EscapeDataString(state.ClassName), state.ObjectId)),
+              string.Format("classes/{0}", Uri.EscapeDataString(state.ClassName)) :
+              string.Format("classes/{0}/{1}", Uri.EscapeDataString(state.ClassName), state.ObjectId)),
           method: (state.ObjectId == null ? "POST" : "PUT"),
           sessionToken: sessionToken,
           data: objectJSON);
@@ -78,7 +78,7 @@ namespace Parse.Internal {
     public Task DeleteAsync(IObjectState state,
         string sessionToken,
         CancellationToken cancellationToken) {
-      var command = new ParseCommand(string.Format("/1/classes/{0}/{1}",
+      var command = new ParseCommand(string.Format("classes/{0}/{1}",
               state.ClassName, state.ObjectId),
           method: "DELETE",
           sessionToken: sessionToken,

--- a/Parse/Internal/Object/Controller/ParseObjectController.cs
+++ b/Parse/Internal/Object/Controller/ParseObjectController.cs
@@ -55,14 +55,15 @@ namespace Parse.Internal {
         IList<IDictionary<string, IParseFieldOperation>> operationsList,
         string sessionToken,
         CancellationToken cancellationToken) {
-      var requests = states.Zip(operationsList, (item, ops) => new Dictionary<string, object> {
-        { "method", (item.ObjectId == null ? "POST" : "PUT") },
-        { "path",  (item.ObjectId == null ?
-            string.Format("/1/classes/{0}", Uri.EscapeDataString(item.ClassName)) :
-            string.Format("/1/classes/{0}/{1}", Uri.EscapeDataString(item.ClassName),
-                Uri.EscapeDataString(item.ObjectId))) },
-        { "body", ParseObject.ToJSONObjectForSaving(ops) }
-      }).Cast<object>().ToList();
+
+      var requests = states
+        .Zip(operationsList, (item, ops) => new ParseCommand(
+          item.ObjectId == null
+            ? string.Format("classes/{0}", Uri.EscapeDataString(item.ClassName))
+            : string.Format("classes/{0}/{1}", Uri.EscapeDataString(item.ClassName), Uri.EscapeDataString(item.ObjectId)),
+          method: item.ObjectId == null ? "POST" : "PUT",
+          data: ParseObject.ToJSONObjectForSaving(ops)))
+        .ToList();
 
       var batchTasks = ExecuteBatchRequests(requests, sessionToken, cancellationToken);
       var stateTasks = new List<Task<IObjectState>>();
@@ -90,24 +91,25 @@ namespace Parse.Internal {
     public IList<Task> DeleteAllAsync(IList<IObjectState> states,
         string sessionToken,
         CancellationToken cancellationToken) {
-      var requests = states.Where(item => item.ObjectId != null).Select(item => new Dictionary<string, object> {
-        { "method", "DELETE" },
-        { "path", string.Format("/1/classes/{0}/{1}", Uri.EscapeDataString(item.ClassName),
-            Uri.EscapeDataString(item.ObjectId)) }
-      }).Cast<object>().ToList();
-
+      var requests = states
+        .Where(item => item.ObjectId != null)
+        .Select(item => new ParseCommand(
+          string.Format("classes/{0}/{1}", Uri.EscapeDataString(item.ClassName), Uri.EscapeDataString(item.ObjectId)),
+            method: "DELETE",
+            data: null))
+        .ToList();
       return ExecuteBatchRequests(requests, sessionToken, cancellationToken).Cast<Task>().ToList();
     }
 
     // TODO (hallucinogen): move this out to a class to be used by Analytics
     private const int MaximumBatchSize = 50;
-    internal IList<Task<IDictionary<string, object>>> ExecuteBatchRequests(IList<object> requests,
+    internal IList<Task<IDictionary<string, object>>> ExecuteBatchRequests(IList<ParseCommand> requests,
         string sessionToken,
         CancellationToken cancellationToken) {
       var tasks = new List<Task<IDictionary<string, object>>>();
       int batchSize = requests.Count;
 
-      IEnumerable<object> remaining = requests;
+      IEnumerable<ParseCommand> remaining = requests;
       while (batchSize > MaximumBatchSize) {
         var process = remaining.Take(MaximumBatchSize).ToList();
         remaining = remaining.Skip(MaximumBatchSize);
@@ -121,7 +123,7 @@ namespace Parse.Internal {
       return tasks;
     }
 
-    private IList<Task<IDictionary<string, object>>> ExecuteBatchRequest(IList<object> requests,
+    private IList<Task<IDictionary<string, object>>> ExecuteBatchRequest(IList<ParseCommand> requests,
         string sessionToken,
         CancellationToken cancellationToken) {
       var tasks = new List<Task<IDictionary<string, object>>>();
@@ -133,10 +135,21 @@ namespace Parse.Internal {
         tasks.Add(tcs.Task);
       }
 
-      var command = new ParseCommand("/1/batch",
+      var encodedRequests = requests.Select(r => {
+        var results = new Dictionary<string, object> {
+          { "method", r.Method },
+          { "path", r.Uri.AbsolutePath },
+        };
+
+        if (r.DataObject != null) {
+          results["body"] = r.DataObject;
+        }
+        return results;
+      }).Cast<object>().ToList();
+      var command = new ParseCommand("batch",
         method: "POST",
         sessionToken: sessionToken,
-        data: new Dictionary<string, object> { { "requests", requests } });
+        data: new Dictionary<string, object> { { "requests", encodedRequests } });
 
       commandRunner.RunCommandAsync(command, cancellationToken: cancellationToken).ContinueWith(t => {
         if (t.IsFaulted || t.IsCanceled) {

--- a/Parse/Internal/Push/Controller/ParsePushController.cs
+++ b/Parse/Internal/Push/Controller/ParsePushController.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Parse.Internal {
   internal class ParsePushController : IParsePushController {
     public Task SendPushNotificationAsync(IPushState state, String sessionToken, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/push",
+      var command = new ParseCommand("push",
           method: "POST",
           sessionToken: sessionToken,
           data: ParsePushEncoder.Instance.Encode(state));

--- a/Parse/Internal/Query/Controller/ParseQueryController.cs
+++ b/Parse/Internal/Query/Controller/ParseQueryController.cs
@@ -59,7 +59,7 @@ namespace Parse.Internal {
         IDictionary<string, object> parameters,
         string sessionToken,
         CancellationToken cancellationToken) {
-      var command = new ParseCommand(string.Format("/1/classes/{0}?{1}",
+      var command = new ParseCommand(string.Format("classes/{0}?{1}",
               Uri.EscapeDataString(className),
               ParseClient.BuildQueryString(parameters)),
           method: "GET",

--- a/Parse/Internal/Session/Controller/ParseSessionController.cs
+++ b/Parse/Internal/Session/Controller/ParseSessionController.cs
@@ -14,7 +14,7 @@ namespace Parse.Internal {
     }
 
     public Task<IObjectState> GetSessionAsync(string sessionToken, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/sessions/me",
+      var command = new ParseCommand("sessions/me",
           method: "GET",
           sessionToken: sessionToken,
           data: null);
@@ -25,7 +25,7 @@ namespace Parse.Internal {
     }
 
     public Task RevokeAsync(string sessionToken, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/logout",
+      var command = new ParseCommand("logout",
           method: "POST",
           sessionToken: sessionToken,
           data: new Dictionary<string, object>());
@@ -34,7 +34,7 @@ namespace Parse.Internal {
     }
 
     public Task<IObjectState> UpgradeToRevocableSessionAsync(string sessionToken, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/upgradeToRevocableSession",
+      var command = new ParseCommand("upgradeToRevocableSession",
           method: "POST",
           sessionToken: sessionToken,
           data: new Dictionary<string, object>());

--- a/Parse/Internal/User/Controller/ParseUserController.cs
+++ b/Parse/Internal/User/Controller/ParseUserController.cs
@@ -18,7 +18,7 @@ namespace Parse.Internal {
         CancellationToken cancellationToken) {
       var objectJSON = ParseObject.ToJSONObjectForSaving(operations);
 
-      var command = new ParseCommand("/1/classes/_User",
+      var command = new ParseCommand("classes/_User",
           method: "POST",
           data: objectJSON);
 
@@ -39,7 +39,7 @@ namespace Parse.Internal {
         {"password", password}
       };
 
-      var command = new ParseCommand(string.Format("/1/login?{0}", ParseClient.BuildQueryString(data)),
+      var command = new ParseCommand(string.Format("login?{0}", ParseClient.BuildQueryString(data)),
           method: "GET",
           data: null);
 
@@ -58,7 +58,7 @@ namespace Parse.Internal {
       var authData = new Dictionary<string, object>();
       authData[authType] = data;
 
-      var command = new ParseCommand("/1/users",
+      var command = new ParseCommand("users",
           method: "POST",
           data: new Dictionary<string, object> {
             {"authData", authData}
@@ -74,7 +74,7 @@ namespace Parse.Internal {
     }
 
     public Task<IObjectState> GetUserAsync(string sessionToken, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/users/me",
+      var command = new ParseCommand("users/me",
           method: "GET",
           sessionToken: sessionToken,
           data: null);
@@ -85,7 +85,7 @@ namespace Parse.Internal {
     }
 
     public Task RequestPasswordResetAsync(string email, CancellationToken cancellationToken) {
-      var command = new ParseCommand("/1/requestPasswordReset",
+      var command = new ParseCommand("requestPasswordReset",
           method: "POST",
           data: new Dictionary<string, object> {
             {"email", email}

--- a/Parse/ParseClient.cs
+++ b/Parse/ParseClient.cs
@@ -82,7 +82,7 @@ namespace Parse {
     /// </param>
     public static void Initialize(string applicationId, string dotnetKey) {
       lock (mutex) {
-        HostName = HostName ?? new Uri("https://api.parse.com/");
+        HostName = HostName ?? new Uri("https://api.parse.com/1/");
         ApplicationId = applicationId;
         WindowsKey = dotnetKey;
 

--- a/ParseTest.Unit/AnalyticsControllerTests.cs
+++ b/ParseTest.Unit/AnalyticsControllerTests.cs
@@ -14,7 +14,7 @@ namespace ParseTest {
   public class AnalyticsControllerTests {
     [SetUp]
     public void SetUp() {
-      ParseClient.HostName = new Uri("http://parse.com");
+      ParseClient.HostName = new Uri("http://api.parse.local/1/");
     }
 
     [TearDown]

--- a/ParseTest.Unit/CommandTests.cs
+++ b/ParseTest.Unit/CommandTests.cs
@@ -15,7 +15,7 @@ namespace ParseTest {
   public class CommandTests {
     [SetUp]
     public void SetUp() {
-      ParseClient.HostName = new Uri("http://parse.com");
+      ParseClient.HostName = new Uri("http://api.parse.local/1/");
     }
 
     [TearDown]
@@ -26,7 +26,7 @@ namespace ParseTest {
 
     [Test]
     public void TestMakeCommand() {
-      ParseCommand command = new ParseCommand("/1/endpoint",
+      ParseCommand command = new ParseCommand("endpoint",
           method: "GET",
           sessionToken: "abcd",
           headers: null,
@@ -49,7 +49,7 @@ namespace ParseTest {
           It.IsAny<CancellationToken>())).Returns(fakeResponse);
 
       ParseCommandRunner commandRunner = new ParseCommandRunner(mockHttpClient.Object);
-      var command = new ParseCommand("/1/endpoint", method: "GET", data: null);
+      var command = new ParseCommand("endpoint", method: "GET", data: null);
       return commandRunner.RunCommandAsync(command).ContinueWith(t => {
         Assert.False(t.IsFaulted);
         Assert.False(t.IsCanceled);
@@ -69,7 +69,7 @@ namespace ParseTest {
           It.IsAny<CancellationToken>())).Returns(fakeResponse);
 
       ParseCommandRunner commandRunner = new ParseCommandRunner(mockHttpClient.Object);
-      var command = new ParseCommand("/1/endpoint", method: "GET", data: null);
+      var command = new ParseCommand("endpoint", method: "GET", data: null);
       return commandRunner.RunCommandAsync(command).ContinueWith(t => {
         Assert.False(t.IsFaulted);
         Assert.False(t.IsCanceled);
@@ -91,7 +91,7 @@ namespace ParseTest {
           It.IsAny<CancellationToken>())).Returns(fakeResponse);
 
       ParseCommandRunner commandRunner = new ParseCommandRunner(mockHttpClient.Object);
-      var command = new ParseCommand("/1/endpoint", method: "GET", data: null);
+      var command = new ParseCommand("endpoint", method: "GET", data: null);
       return commandRunner.RunCommandAsync(command).ContinueWith(t => {
         Assert.True(t.IsFaulted);
         Assert.False(t.IsCanceled);
@@ -112,7 +112,7 @@ namespace ParseTest {
           It.IsAny<CancellationToken>())).Returns(fakeResponse);
 
       ParseCommandRunner commandRunner = new ParseCommandRunner(mockHttpClient.Object);
-      var command = new ParseCommand("/1/endpoint", method: "GET", data: null);
+      var command = new ParseCommand("endpoint", method: "GET", data: null);
       return commandRunner.RunCommandAsync(command).ContinueWith(t => {
         Assert.True(t.IsFaulted);
         Assert.False(t.IsCanceled);
@@ -134,7 +134,7 @@ namespace ParseTest {
           It.IsAny<CancellationToken>())).Returns(fakeResponse);
 
       ParseCommandRunner commandRunner = new ParseCommandRunner(mockHttpClient.Object);
-      var command = new ParseCommand("/1/endpoint", method: "GET", data: null);
+      var command = new ParseCommand("endpoint", method: "GET", data: null);
       return commandRunner.RunCommandAsync(command).ContinueWith(t => {
         Assert.True(t.IsFaulted);
         Assert.False(t.IsCanceled);

--- a/ParseTest.Unit/ObjectControllerTests.cs
+++ b/ParseTest.Unit/ObjectControllerTests.cs
@@ -15,7 +15,7 @@ namespace ParseTest {
   public class ObjectControllerTests {
     [SetUp]
     public void SetUp() {
-      ParseClient.HostName = new Uri("http://parse.com");
+      ParseClient.HostName = new Uri("http://api.parse.local/1/");
     }
 
     [TearDown]

--- a/ParseTest.Unit/SessionControllerTests.cs
+++ b/ParseTest.Unit/SessionControllerTests.cs
@@ -15,7 +15,7 @@ namespace ParseTest {
   public class SessionControllerTests {
     [SetUp]
     public void SetUp() {
-      ParseClient.HostName = new Uri("http://parse.com");
+      ParseClient.HostName = new Uri("http://api.parse.local/1/");
     }
 
     [TearDown]

--- a/ParseTest.Unit/UserControllerTests.cs
+++ b/ParseTest.Unit/UserControllerTests.cs
@@ -14,7 +14,7 @@ namespace ParseTest {
   public class UserControllerTests {
     [SetUp]
     public void SetUp() {
-      ParseClient.HostName = new Uri("http://parse.com");
+      ParseClient.HostName = new Uri("http://api.parse.local/1/");
     }
 
     [TearDown]


### PR DESCRIPTION
This allows us to more easily do path redirection while performing tests.

Also: Make batch requests no longer require manual encoding.

Now leverages the existing 'ParseCommand' class instead of constructing improperly typed dictionaries.