### PR TITLE
Add better, more flexible APIs for SDK initialization.

### DIFF
--- a/Parse/Internal/Command/ParseCommand.cs
+++ b/Parse/Internal/Command/ParseCommand.cs
@@ -50,8 +50,10 @@ namespace Parse.Internal {
       Method = method;
       Data = stream;
 
+      // TODO (richardross): Inject configuration instead of using shared static here.
       Headers = new List<KeyValuePair<string, string>> {
-        new KeyValuePair<string, string>("X-Parse-Application-Id", ParseClient.ApplicationId),
+        new KeyValuePair<string, string>("X-Parse-Application-Id", ParseClient.CurrentConfiguration.ApplicationId),
+        new KeyValuePair<string, string>("X-Parse-Windows-Key", ParseClient.CurrentConfiguration.WindowsKey),
         new KeyValuePair<string, string>("X-Parse-Client-Version", ParseClient.VersionString),
         new KeyValuePair<string, string>("X-Parse-Installation-Id", ParseClient.InstallationId.ToString())
       };
@@ -71,10 +73,12 @@ namespace Parse.Internal {
       if (!string.IsNullOrEmpty(ParseClient.PlatformHooks.OSVersion)) {
         Headers.Add(new KeyValuePair<string, string>("X-Parse-OS-Version", ParseClient.PlatformHooks.OSVersion));
       }
+      // TODO (richardross): I hate the idea of having this super tightly coupled static variable in here.
+      // Lets eventually get rid of it.
       if (!string.IsNullOrEmpty(ParseClient.MasterKey)) {
         Headers.Add(new KeyValuePair<string, string>("X-Parse-Master-Key", ParseClient.MasterKey));
       } else {
-        Headers.Add(new KeyValuePair<string, string>("X-Parse-Windows-Key", ParseClient.WindowsKey));
+        Headers.Add(new KeyValuePair<string, string>("X-Parse-Windows-Key", ParseClient.CurrentConfiguration.WindowsKey));
       }
       if (!string.IsNullOrEmpty(sessionToken)) {
         Headers.Add(new KeyValuePair<string, string>("X-Parse-Session-Token", sessionToken));

--- a/Parse/Public/ParseClient.cs
+++ b/Parse/Public/ParseClient.cs
@@ -28,6 +28,20 @@ namespace Parse {
       "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'f'Z'",
     };
 
+    /// <summary>
+    /// Represents the configuration of the Parse SDK.
+    /// </summary>
+    public struct Configuration {
+      /// <summary>
+      /// The Parse.com application ID of your app.
+      /// </summary>
+      public String ApplicationId { get; set; }
+
+      /// <summary>
+      /// The Parse.com .NET key for your app.
+      /// </summary>
+      public String WindowsKey { get; set; }
+    }
 
     private static readonly object mutex = new object();
     private static readonly string[] assemblyNames = {
@@ -60,10 +74,12 @@ namespace Parse {
     private static readonly IParseCommandRunner commandRunner;
     internal static IParseCommandRunner ParseCommandRunner { get { return commandRunner; } }
 
+    /// <summary>
+    /// The current configuration that parse has been initialized with.
+    /// </summary>
+    public static Configuration CurrentConfiguration { get; internal set; }
     internal static Uri HostName { get; set; }
     internal static string MasterKey { get; set; }
-    internal static string ApplicationId { get; set; }
-    internal static string WindowsKey { get; set; }
 
     internal static Version Version {
       get {
@@ -90,10 +106,24 @@ namespace Parse {
     /// <param name="dotnetKey">The .NET API Key provided in the Parse dashboard.
     /// </param>
     public static void Initialize(string applicationId, string dotnetKey) {
+      Initialize(new Configuration {
+        ApplicationId = applicationId,
+        WindowsKey = dotnetKey
+      });
+    }
+
+    /// <summary>
+    /// Authenticates this client as belonging to your application. This must be
+    /// called before your application can use the Parse library. The recommended
+    /// way is to put a call to <c>ParseFramework.Initialize</c> in your
+    /// Application startup.
+    /// </summary>
+    /// <param name="configuration">The configuration to initialze Parse with.
+    /// </param>
+    public static void Initialize(Configuration configuration) {
       lock (mutex) {
         HostName = HostName ?? new Uri("https://api.parse.com/1/");
-        ApplicationId = applicationId;
-        WindowsKey = dotnetKey;
+        CurrentConfiguration = configuration;
 
         ParseObject.RegisterSubclass<ParseUser>();
         ParseObject.RegisterSubclass<ParseInstallation>();


### PR DESCRIPTION
## This PR includes public API changes

Proposing a new initialization API, to allow for more flexibility and clarity in the future:

````csharp
ParseClient.Initialize(new ParseClient.Configuration {
    ApplicationId = ...,
    WindowsKey = ...
});
````

No APIs are being directly deprecated at this time, only additions for the time being.

-----------

This PR hopes to unify some of these initialization settings int o a single 'configuration' class that can be easily used to intialize parse in a much cleaner way, especially as we add even more initialization options.

Depends on #77.