### PR TITLE
Fix several continuations inside of HttpClient.

### DIFF
--- a/Parse/Internal/HttpClient.Android.cs
+++ b/Parse/Internal/HttpClient.Android.cs
@@ -66,8 +66,7 @@ namespace Parse.Internal {
 
         uploadTask = copyTask.Safe().ContinueWith(_ => {
           return request.GetRequestStreamAsync();
-        }).Unwrap()
-        .OnSuccess(t => {
+        }).Unwrap().OnSuccess(t => {
           var requestStream = t.Result;
 
           int bufferSize = 4096;
@@ -89,14 +88,14 @@ namespace Parse.Internal {
             });
           }).ContinueWith(_ => {
             requestStream.Close();
-          });
+            return _;
+          }).Unwrap();
         }).Unwrap();
       }
 
-      return uploadTask.Safe().ContinueWith(_ => {
+      return uploadTask.Safe().OnSuccess(_ => {
         return request.GetResponseAsync();
-      }).Unwrap()
-      .ContinueWith(t => {
+      }).Unwrap().OnSuccess(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/Parse/Internal/HttpClient.Phone.cs
+++ b/Parse/Internal/HttpClient.Phone.cs
@@ -94,7 +94,8 @@ namespace Parse.Internal {
             });
           }).ContinueWith(_ => {
             requestStream.Close();
-          });
+            return _;
+          }).Unwrap();
         }).Unwrap();
       }
 

--- a/Parse/Internal/HttpClient.iOS.cs
+++ b/Parse/Internal/HttpClient.iOS.cs
@@ -67,8 +67,7 @@ namespace Parse.Internal {
 
         uploadTask = copyTask.Safe().ContinueWith(_ => {
           return request.GetRequestStreamAsync();
-        }).Unwrap()
-        .OnSuccess(t => {
+        }).Unwrap().OnSuccess(t => {
           var requestStream = t.Result;
 
           int bufferSize = 4096;
@@ -90,14 +89,14 @@ namespace Parse.Internal {
             });
           }).ContinueWith(_ => {
             requestStream.Close();
-          });
+            return _;
+          }).Unwrap();
         }).Unwrap();
       }
 
-      return uploadTask.Safe().ContinueWith(_ => {
+      return uploadTask.Safe().OnSuccess(_ => {
         return request.GetResponseAsync();
-      }).Unwrap()
-      .ContinueWith(t => {
+      }).Unwrap().OnSuccess(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
This was causing errors to happen at certain parts of the process to be discarded, leading to crashes because we never read from the Task.Exception.

Fixes #81.