### PR TITLE
Support any number of trailing zeroes when decoding dates.

### DIFF
--- a/Parse/Internal/FacebookAuthenticationProvider.cs
+++ b/Parse/Internal/FacebookAuthenticationProvider.cs
@@ -56,7 +56,7 @@ namespace Parse.Internal {
       return new Dictionary<string, object> {
         {"id", facebookId},
         {"access_token", accessToken},
-        {"expiration_date", expiration.ToString(ParseClient.DateFormatString)}
+        {"expiration_date", expiration.ToString(ParseClient.DateFormatStrings.First())}
       };
     }
 

--- a/Parse/Internal/Installation/Controller/ParseCurrentInstallationController.cs
+++ b/Parse/Internal/Installation/Controller/ParseCurrentInstallationController.cs
@@ -41,10 +41,10 @@ namespace Parse.Internal {
             var data = installation.ServerDataToJSONObjectForSerialization();
             data["objectId"] = installation.ObjectId;
             if (installation.CreatedAt != null) {
-              data["createdAt"] = installation.CreatedAt.Value.ToString(ParseClient.DateFormatString);
+              data["createdAt"] = installation.CreatedAt.Value.ToString(ParseClient.DateFormatStrings.First());
             }
             if (installation.UpdatedAt != null) {
-              data["updatedAt"] = installation.UpdatedAt.Value.ToString(ParseClient.DateFormatString);
+              data["updatedAt"] = installation.UpdatedAt.Value.ToString(ParseClient.DateFormatStrings.First());
             }
 
             ParseClient.ApplicationSettings["CurrentInstallation"] = Json.Encode(data);

--- a/Parse/Internal/ParseDecoder.cs
+++ b/Parse/Internal/ParseDecoder.cs
@@ -97,8 +97,9 @@ namespace Parse.Internal {
       // TODO(hallucinogen): Figure out if we should be more flexible with the date formats
       // we accept.
       return DateTime.ParseExact(input,
-          ParseClient.DateFormatString,
-          CultureInfo.InvariantCulture);
+        ParseClient.DateFormatStrings,
+        CultureInfo.InvariantCulture,
+        DateTimeStyles.None);
     }
   }
 }

--- a/Parse/Internal/ParseEncoder.cs
+++ b/Parse/Internal/ParseEncoder.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Parse.Internal {
   /// <summary>
@@ -31,7 +32,7 @@ namespace Parse.Internal {
       // encoded object. Otherwise, just return the original object.
       if (value is DateTime) {
         return new Dictionary<string, object> {
-          {"iso", ((DateTime)value).ToString(ParseClient.DateFormatString)},
+          {"iso", ((DateTime)value).ToString(ParseClient.DateFormatStrings.First())},
           {"__type", "Date"}
         };
       }

--- a/Parse/Internal/User/Controller/ParseCurrentUserController.cs
+++ b/Parse/Internal/User/Controller/ParseCurrentUserController.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,10 +35,10 @@ namespace Parse.Internal {
             var data = user.ServerDataToJSONObjectForSerialization();
             data["objectId"] = user.ObjectId;
             if (user.CreatedAt != null) {
-              data["createdAt"] = user.CreatedAt.Value.ToString(ParseClient.DateFormatString);
+              data["createdAt"] = user.CreatedAt.Value.ToString(ParseClient.DateFormatStrings.First());
             }
             if (user.UpdatedAt != null) {
-              data["updatedAt"] = user.UpdatedAt.Value.ToString(ParseClient.DateFormatString);
+              data["updatedAt"] = user.UpdatedAt.Value.ToString(ParseClient.DateFormatStrings.First());
             }
 
             ParseClient.ApplicationSettings["CurrentUser"] = Json.Encode(data);

--- a/Parse/ParseClient.cs
+++ b/Parse/ParseClient.cs
@@ -18,7 +18,16 @@ namespace Parse {
   /// configuration for the Parse library.
   /// </summary>
   public static partial class ParseClient {
-    internal const string DateFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'";
+    internal static readonly string[] DateFormatStrings = {
+      // Official ISO format
+      "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'",
+
+      // It's possible that the string converter server-side may trim trailing zeroes,
+      // so these two formats cover ourselves from that.
+      "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ff'Z'",
+      "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'f'Z'",
+    };
+
 
     private static readonly object mutex = new object();
     private static readonly string[] assemblyNames = {

--- a/ParseTest.Unit/DecoderTests.cs
+++ b/ParseTest.Unit/DecoderTests.cs
@@ -57,6 +57,38 @@ namespace ParseTest {
     }
 
     [Test]
+    public void TestDecodeImproperDate() {
+      IDictionary<string, object> value = new Dictionary<string, object>() {
+        { "__type", "Date" },
+        { "iso", "1990-08-30T12:03:59.0Z" }
+      };
+
+      DateTime dateTime = (DateTime)ParseDecoder.Instance.Decode(value);
+      Assert.AreEqual(1990, dateTime.Year);
+      Assert.AreEqual(8, dateTime.Month);
+      Assert.AreEqual(30, dateTime.Day);
+      Assert.AreEqual(12, dateTime.Hour);
+      Assert.AreEqual(3, dateTime.Minute);
+      Assert.AreEqual(59, dateTime.Second);
+      Assert.AreEqual(0, dateTime.Millisecond);
+
+      // Test multiple trailing zeroes
+      value = new Dictionary<string, object>() {
+        { "__type", "Date" },
+        { "iso", "1990-08-30T12:03:59.00Z" }
+      };
+
+      dateTime = (DateTime)ParseDecoder.Instance.Decode(value);
+      Assert.AreEqual(1990, dateTime.Year);
+      Assert.AreEqual(8, dateTime.Month);
+      Assert.AreEqual(30, dateTime.Day);
+      Assert.AreEqual(12, dateTime.Hour);
+      Assert.AreEqual(3, dateTime.Minute);
+      Assert.AreEqual(59, dateTime.Second);
+      Assert.AreEqual(0, dateTime.Millisecond);
+    }
+
+    [Test]
     public void TestDecodeBytes() {
       IDictionary<string, object> value = new Dictionary<string, object>() {
         { "__type", "Bytes" },


### PR DESCRIPTION
This was causing sporadic issues when the server returns dates that are valid according to the ISO standard, but not according to DateTime.ParseExact.

Fixes #64.