### PR TITLE
FacebookAuthenticationProvider.cs fix

### DIFF
--- a/Parse/Internal/FacebookAuthenticationProvider.cs
+++ b/Parse/Internal/FacebookAuthenticationProvider.cs
@@ -75,7 +75,8 @@ namespace Parse.Internal {
             parameters["fields"] = "id";
 
             var request = new HttpRequest {
-              Uri = new Uri(MeUrl, "?" + ParseClient.BuildQueryString(parameters))
+              Uri = new Uri(MeUrl, "?" + ParseClient.BuildQueryString(parameters)),
+              Method = "GET"
             };
 
             ParseClient.PlatformHooks.HttpClient.ExecuteAsync(request, null, null, CancellationToken.None).OnSuccess(t => {


### PR DESCRIPTION
Passing null 'Method' causes ArgumentException (Cannot set null or blank methods on request) so ParseFacebookUtils doesn't work at all.