### PR TITLE
[Typo] Fixes typo in Parse/Internal/Json.cs

### DIFF
--- a/Parse/Internal/Json.cs
+++ b/Parse/Internal/Json.cs
@@ -353,7 +353,7 @@ namespace Parse.Internal {
     }
 
     /// <summary>
-    /// Encodes a list into a JSON string. Suppots values that are
+    /// Encodes a list into a JSON string. Supports values that are
     /// IDictionary&lt;string, object&gt;, IList&lt;object&gt;, strings,
     /// nulls, and any of the primitive types.
     /// </summary>


### PR DESCRIPTION
Found another typo of the word support.  Surprised I missed it last time!