### PR TITLE
Add UNIT_TEST constant to ParseTest.Unit

### DIFF
--- a/Parse/Properties/AssemblyInfo.Portable.cs
+++ b/Parse/Properties/AssemblyInfo.Portable.cs
@@ -15,13 +15,14 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ParseTest.Integration.NetFx45")]
 [assembly: InternalsVisibleTo("ParseTest.Integration.Phone")]
 
-[assembly: InternalsVisibleTo("ParseTest.Unit.NetFx45")]
-
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-
 // Internal visibility for sample projects
 [assembly: InternalsVisibleTo("ParsePushSample")]
 [assembly: InternalsVisibleTo("ParsePhonePushSample")]
+
+#if UNIT_TEST
+[assembly: InternalsVisibleTo("ParseTest.Unit.NetFx45")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif
 
 #if MONO
 [assembly: InternalsVisibleTo("ParseTestIntegrationiOS")]

--- a/ParseTest.Unit/ParseTest.Unit.NetFx45.csproj
+++ b/ParseTest.Unit/ParseTest.Unit.NetFx45.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NETFX</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;UNIT_TEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;UNIT_TEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
We want to sign the .dlls generated from this repo. But in order to do that we'll need to rule `DynamicProxyGenAssembly2` out of our build AssemblyInfo unless we're building a unit test project. The reason is that we can't add the signing key into `DynamicProxyGenAssembly2` (which is part of an open-source project), and thus preventing us to compile the projects.

First of multiple PR that will fix #46