### PR TITLE
Made all methods in ReflectionHelpers non-extensions.

### DIFF
--- a/Parse/Internal/Json.cs
+++ b/Parse/Internal/Json.cs
@@ -419,7 +419,7 @@ namespace Parse.Internal {
           return "false";
         }
       }
-      if (!obj.GetType().IsPrimitive()) {
+      if (!ReflectionHelpers.IsPrimitive(obj.GetType())) {
         throw new ArgumentException("Unable to encode objects of type " + obj.GetType());
       }
       return Convert.ToString(obj, CultureInfo.InvariantCulture);

--- a/Parse/Internal/Object/Subclassing/ObjectSubclassInfo.cs
+++ b/Parse/Internal/Object/Subclassing/ObjectSubclassInfo.cs
@@ -16,7 +16,7 @@ namespace Parse.Internal {
       TypeInfo = type.GetTypeInfo();
       ClassName = GetClassName(TypeInfo);
       Constructor = constructor;
-      PropertyMappings = type.GetProperties()
+      PropertyMappings = ReflectionHelpers.GetProperties(type)
         .Select(prop => Tuple.Create(prop, prop.GetCustomAttribute<ParseFieldNameAttribute>(true)))
         .Where(t => t.Item2 != null)
         .Select(t => Tuple.Create(t.Item1, t.Item2.FieldName))

--- a/Parse/Internal/ParseEncoder.cs
+++ b/Parse/Internal/ParseEncoder.cs
@@ -14,7 +14,7 @@ namespace Parse.Internal {
   internal abstract class ParseEncoder {
     public static bool IsValidType(object value) {
       return value == null ||
-          value.GetType().IsPrimitive() ||
+          ReflectionHelpers.IsPrimitive(value.GetType()) ||
           value is string ||
           value is ParseObject ||
           value is ParseACL ||

--- a/Parse/Internal/ReflectionHelpers.cs
+++ b/Parse/Internal/ReflectionHelpers.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Parse.Internal {
   static class ReflectionHelpers {
-    internal static IEnumerable<PropertyInfo> GetProperties(this Type type) {
+    internal static IEnumerable<PropertyInfo> GetProperties(Type type) {
 #if MONO || UNITY
       return type.GetProperties();
 #else
@@ -15,7 +15,7 @@ namespace Parse.Internal {
 #endif
     }
 
-    internal static MethodInfo GetMethod(this Type type, string name, Type[] parameters) {
+    internal static MethodInfo GetMethod(Type type, string name, Type[] parameters) {
 #if MONO || UNITY
       return type.GetMethod(name, parameters);
 #else
@@ -23,7 +23,7 @@ namespace Parse.Internal {
 #endif
     }
 
-    internal static bool IsPrimitive(this Type type) {
+    internal static bool IsPrimitive(Type type) {
 #if MONO
 			return type.IsPrimitive;
 #else
@@ -31,7 +31,7 @@ namespace Parse.Internal {
 #endif
     }
 
-    internal static IEnumerable<Type> GetInterfaces(this Type type) {
+    internal static IEnumerable<Type> GetInterfaces(Type type) {
 #if MONO || UNITY
       return type.GetInterfaces();
 #else
@@ -39,7 +39,7 @@ namespace Parse.Internal {
 #endif
     }
 
-    internal static bool IsConstructedGenericType(this Type type) {
+    internal static bool IsConstructedGenericType(Type type) {
 #if UNITY
       return type.IsGenericType && !type.IsGenericTypeDefinition;
 #else
@@ -47,7 +47,7 @@ namespace Parse.Internal {
 #endif
     }
 
-    internal static IEnumerable<ConstructorInfo> GetConstructors(this Type type) {
+    internal static IEnumerable<ConstructorInfo> GetConstructors(Type type) {
 #if UNITY
       BindingFlags searchFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
       return type.GetConstructors(searchFlags);
@@ -57,11 +57,19 @@ namespace Parse.Internal {
 #endif
     }
 
-    internal static Type[] GetGenericTypeArguments(this Type type) {
+    internal static Type[] GetGenericTypeArguments(Type type) {
 #if UNITY
       return type.GetGenericArguments();
 #else
       return type.GenericTypeArguments;
+#endif
+    }
+
+    internal static PropertyInfo GetProperty(Type type, string name) {
+#if MONO || UNITY
+      return type.GetProperty(name);
+#else
+      return type.GetRuntimeProperty(name);
 #endif
     }
 
@@ -75,7 +83,7 @@ namespace Parse.Internal {
     /// <returns></returns>
     internal static ConstructorInfo FindConstructor(this Type self, params Type[] parameterTypes) {
       var constructors =
-        from constructor in self.GetConstructors()
+        from constructor in GetConstructors(self)
         let parameters = constructor.GetParameters()
         let types = from p in parameters select p.ParameterType
         where types.SequenceEqual(parameterTypes)
@@ -83,15 +91,7 @@ namespace Parse.Internal {
       return constructors.SingleOrDefault();
     }
 
-    internal static PropertyInfo GetProperty(this Type type, string name) {
-#if MONO || UNITY
-      return type.GetProperty(name);
-#else
-      return type.GetRuntimeProperty(name);
-#endif
-    }
-
-    internal static bool IsNullable(this Type t) {
+    internal static bool IsNullable(Type t) {
       bool isGeneric;
 #if UNITY
       isGeneric = t.IsGenericType && !t.IsGenericTypeDefinition;

--- a/Parse/ParseClient.cs
+++ b/Parse/ParseClient.cs
@@ -137,30 +137,32 @@ namespace Parse {
         return value;
       }
 
-      if (typeof(T).IsPrimitive()) {
+      if (ReflectionHelpers.IsPrimitive(typeof(T))) {
         return (T)Convert.ChangeType(value, typeof(T));
       }
 
-      if (typeof(T).IsConstructedGenericType()) {
+      if (ReflectionHelpers.IsConstructedGenericType(typeof(T))) {
         // Add lifting for nullables. Only supports conversions between primitives.
-        if (typeof(T).IsNullable()) {
-          var innerType = typeof(T).GetGenericTypeArguments()[0];
-          if (innerType.IsPrimitive()) {
+        if (ReflectionHelpers.IsNullable(typeof(T))) {
+          var innerType = ReflectionHelpers.GetGenericTypeArguments(typeof(T))[0];
+          if (ReflectionHelpers.IsPrimitive(innerType)) {
             return (T)Convert.ChangeType(value, innerType);
           }
         }
         Type listType = GetInterfaceType(value.GetType(), typeof(IList<>));
         if (listType != null &&
             typeof(T).GetGenericTypeDefinition() == typeof(IList<>)) {
-          var wrapperType = typeof(FlexibleListWrapper<,>).MakeGenericType(typeof(T).GetGenericTypeArguments()[0],
-              listType.GetGenericTypeArguments()[0]);
+          var wrapperType = typeof(FlexibleListWrapper<,>)
+            .MakeGenericType(ReflectionHelpers.GetGenericTypeArguments(typeof(T))[0],
+                             ReflectionHelpers.GetGenericTypeArguments(listType)[0]);
           return Activator.CreateInstance(wrapperType, value);
         }
         Type dictType = GetInterfaceType(value.GetType(), typeof(IDictionary<,>));
         if (dictType != null &&
-            typeof(T).GetGenericTypeDefinition() == typeof(IDictionary<,>)) {
-          var wrapperType = typeof(FlexibleDictionaryWrapper<,>).MakeGenericType(typeof(T).GetGenericTypeArguments()[1],
-              dictType.GetGenericTypeArguments()[1]);
+          typeof(T).GetGenericTypeDefinition() == typeof(IDictionary<,>)) {
+          var wrapperType = typeof(FlexibleDictionaryWrapper<,>)
+            .MakeGenericType(ReflectionHelpers.GetGenericTypeArguments(typeof(T))[1],
+                             ReflectionHelpers.GetGenericTypeArguments(dictType)[1]);
           return Activator.CreateInstance(wrapperType, value);
         }
       }
@@ -182,15 +184,15 @@ namespace Parse {
       // Side note: It so sucks to have to do this. What a piece of crap bit of code
       // Unfortunately, .NET doesn't provide any of the right hooks to do this for you
       // *sigh*
-      if (genericInterfaceType.IsConstructedGenericType()) {
+      if (ReflectionHelpers.IsConstructedGenericType(genericInterfaceType)) {
         genericInterfaceType = genericInterfaceType.GetGenericTypeDefinition();
       }
       var cacheKey = new Tuple<Type, Type>(objType, genericInterfaceType);
       if (interfaceLookupCache.ContainsKey(cacheKey)) {
         return interfaceLookupCache[cacheKey];
       }
-      foreach (var type in objType.GetInterfaces()) {
-        if (type.IsConstructedGenericType() &&
+      foreach (var type in ReflectionHelpers.GetInterfaces(objType)) {
+        if (ReflectionHelpers.IsConstructedGenericType(type) &&
             type.GetGenericTypeDefinition() == genericInterfaceType) {
           return interfaceLookupCache[cacheKey] = type;
         }

--- a/Parse/ParseConfig.cs
+++ b/Parse/ParseConfig.cs
@@ -93,7 +93,7 @@ namespace Parse {
         var temp = ParseClient.ConvertTo<T>(this.properties[key]);
         if (temp is T ||
           (temp == null &&
-            (!typeof(T).GetTypeInfo().IsValueType || typeof(T).IsNullable()))
+            (!typeof(T).GetTypeInfo().IsValueType || ReflectionHelpers.IsNullable(typeof(T))))
         ) {
           result = (T)temp;
           return true;

--- a/Parse/ParseObject.cs
+++ b/Parse/ParseObject.cs
@@ -1292,7 +1292,7 @@ string propertyName
       lock (mutex) {
         if (ContainsKey(key)) {
           var temp = ParseClient.ConvertTo<T>(this[key]);
-          if (temp is T || (temp == null && (!typeof(T).GetTypeInfo().IsValueType || typeof(T).IsNullable()))) {
+          if (temp is T || (temp == null && (!typeof(T).GetTypeInfo().IsValueType || ReflectionHelpers.IsNullable(typeof(T))))) {
             result = (T)temp;
             return true;
           }

--- a/Parse/ParseQueryExtensions.cs
+++ b/Parse/ParseQueryExtensions.cs
@@ -406,7 +406,7 @@ namespace Parse {
         var containedIn = GetValue(node.Arguments[0]);
         var queryType = translatedMethod.DeclaringType.GetGenericTypeDefinition()
             .MakeGenericType(typeof(T));
-        translatedMethod = queryType.GetMethod(
+        translatedMethod = ReflectionHelpers.GetMethod(queryType,
             translatedMethod.Name,
             translatedMethod.GetParameters().Select(p => p.ParameterType).ToArray());
         return translatedMethod.Invoke(source, new[] { fieldPath, containedIn }) as ParseQuery<T>;


### PR DESCRIPTION
Reason: as we start adding support for more platforms which may or may not have this natively, our extension methods are not guaranteed to be invoked if they have the same name of a builtin method.

My requiring explicit invoking, it allows us to enforce custom logic here.

Fixes #111 (for real this time).