### PR TITLE
[Unity] Fix build error with IL2CPP

### DIFF
--- a/Parse/ParseInstallation.Unity.cs
+++ b/Parse/ParseInstallation.Unity.cs
@@ -43,11 +43,13 @@ namespace Parse {
     public int Badge {
       get {
         if (PlatformHooks.IsIOS) {
-				  PlatformHooks.RunOnMainThread(() => {
+#if IOS
+          PlatformHooks.RunOnMainThread(() => {
             if (UnityEngine.iOS.NotificationServices.localNotificationCount > 0) {
               SetProperty<int>(UnityEngine.iOS.NotificationServices.localNotifications[0].applicationIconBadgeNumber, "Badge");
             }
           });
+#endif
         }
         return GetProperty<int>("Badge");
       }
@@ -55,12 +57,14 @@ namespace Parse {
         int badge = value;
         SetProperty<int>(badge, "Badge");
         if (PlatformHooks.IsIOS) {
+#if IOS
           PlatformHooks.RunOnMainThread(() => {
             UnityEngine.iOS.LocalNotification notification = new UnityEngine.iOS.LocalNotification ();
             notification.applicationIconBadgeNumber = badge;
             notification.hasAction = false;
             UnityEngine.iOS.NotificationServices.PresentLocalNotificationNow(notification);
           });
+#endif
         }
       }
     }

--- a/Parse/PlatformHooks.Unity.cs
+++ b/Parse/PlatformHooks.Unity.cs
@@ -1023,6 +1023,7 @@ namespace Parse {
     /// </summary>
     /// <param name="action">Action to be completed when device token is received.</param>
     internal static void RegisterDeviceTokenRequest(Action<byte[]> action) {
+#if IOS
       RunOnMainThread(() => {
         var deviceToken = UnityEngine.iOS.NotificationServices.deviceToken;
         if (deviceToken != null) {
@@ -1034,6 +1035,7 @@ namespace Parse {
           RegisterDeviceTokenRequest(action);
         }
       });
+#endif
     }
 
     /// <summary>
@@ -1041,6 +1043,7 @@ namespace Parse {
     /// </summary>
     /// <param name="action">Action to be completed when push notification is received.</param>
     internal static void RegisteriOSPushNotificationListener(Action<IDictionary<string, object>> action) {
+#if IOS
       RunOnMainThread(() => {
         int remoteNotificationCount = UnityEngine.iOS.NotificationServices.remoteNotificationCount;
         if (remoteNotificationCount > 0) {
@@ -1062,9 +1065,10 @@ namespace Parse {
         // Check in every frame.
         RegisteriOSPushNotificationListener(action);
       });
+#endif
     }
 
-    #endregion
+#endregion
 
     /// <summary>
     /// Runs things inside of a Unity coroutine (some APIs require that you


### PR DESCRIPTION
Build fails in Unity when compiling with IL2CPP for non-iOS platforms, because UnityEngine.iOS.NotificationServices is not resolvable