### PR TITLE
Prepare .csproj for code signing

### DIFF
--- a/Parse/Parse.NetFx45.csproj
+++ b/Parse/Parse.NetFx45.csproj
@@ -33,9 +33,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\NetFx45\Parse.NetFx45.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -78,6 +75,9 @@
       <Name>Parse</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" Condition="Exists('$(SolutionDir)\.nuget\nuget.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Parse/Parse.Phone.csproj
+++ b/Parse/Parse.Phone.csproj
@@ -86,9 +86,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Internal\**\Phone\*.cs" />
 
@@ -105,6 +102,9 @@
       <Name>Parse</Name>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
   <ProjectExtensions />

--- a/Parse/Parse.WinRT.csproj
+++ b/Parse/Parse.WinRT.csproj
@@ -127,9 +127,6 @@
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>Parse.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" Condition="Exists('$(SolutionDir)\.nuget\nuget.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Parse/Parse.csproj
+++ b/Parse/Parse.csproj
@@ -59,7 +59,9 @@
       <Compile Include="Internal\**\*.cs" Exclude="$(ExcludedPlatformSpecificSourceFilesString)" />
       <Compile Include="Public\**\*.cs" Exclude="$(ExcludedPlatformSpecificSourceFilesString)" />
   </ItemGroup>
-
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" Condition="Exists('$(SolutionDir)\.nuget\nuget.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Parse/Properties/AssemblyInfo.Portable.cs
+++ b/Parse/Properties/AssemblyInfo.Portable.cs
@@ -16,12 +16,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ParseTest.Integration.Phone")]
 
 [assembly: InternalsVisibleTo("ParseTest.Unit.NetFx45")]
-
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-
-// Internal visibility for sample projects
-[assembly: InternalsVisibleTo("ParsePushSample")]
-[assembly: InternalsVisibleTo("ParsePhonePushSample")]
 
 #if MONO
 [assembly: InternalsVisibleTo("ParseTestIntegrationiOS")]


### PR DESCRIPTION
Yet another pull request to prepare us to sign the `.dll`s. Also cleanup legacy code from `Parse/Properties/AssemblyInfo.Portable.cs`