### PR TITLE
Fix internal IntegrationTests

### DIFF
--- a/Parse/Internal/Command/ParseCommand.cs
+++ b/Parse/Internal/Command/ParseCommand.cs
@@ -53,7 +53,6 @@ namespace Parse.Internal {
       // TODO (richardross): Inject configuration instead of using shared static here.
       Headers = new List<KeyValuePair<string, string>> {
         new KeyValuePair<string, string>("X-Parse-Application-Id", ParseClient.CurrentConfiguration.ApplicationId),
-        new KeyValuePair<string, string>("X-Parse-Windows-Key", ParseClient.CurrentConfiguration.WindowsKey),
         new KeyValuePair<string, string>("X-Parse-Client-Version", ParseClient.VersionString),
         new KeyValuePair<string, string>("X-Parse-Installation-Id", ParseClient.InstallationId.ToString())
       };

--- a/Parse/Internal/HttpClient/Android/HttpClient.Android.cs
+++ b/Parse/Internal/HttpClient/Android/HttpClient.Android.cs
@@ -95,7 +95,7 @@ namespace Parse.Internal {
 
       return uploadTask.Safe().OnSuccess(_ => {
         return request.GetResponseAsync();
-      }).Unwrap().OnSuccess(t => {
+      }).Unwrap().ContinueWith(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/Parse/Internal/HttpClient/NetFx45/HttpClient.NetFx45.cs
+++ b/Parse/Internal/HttpClient/NetFx45/HttpClient.NetFx45.cs
@@ -95,7 +95,7 @@ namespace Parse.Internal {
 
       return uploadTask.Safe().OnSuccess(_ => {
         return request.GetResponseAsync();
-      }).Unwrap().OnSuccess(t => {
+      }).Unwrap().ContinueWith(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/Parse/Internal/HttpClient/Phone/HttpClient.Phone.cs
+++ b/Parse/Internal/HttpClient/Phone/HttpClient.Phone.cs
@@ -104,8 +104,7 @@ namespace Parse.Internal {
             request.BeginGetResponse,
             request.EndGetResponse,
             TaskCreationOptions.None);
-      }).Unwrap()
-      .ContinueWith(t => {
+      }).Unwrap().ContinueWith(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/Parse/Internal/HttpClient/WinRT/HttpClient.WinRT.cs
+++ b/Parse/Internal/HttpClient/WinRT/HttpClient.WinRT.cs
@@ -95,7 +95,7 @@ namespace Parse.Internal {
 
       return uploadTask.Safe().OnSuccess(_ => {
         return request.GetResponseAsync();
-      }).Unwrap().OnSuccess(t => {
+      }).Unwrap().ContinueWith(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/Parse/Internal/HttpClient/iOS/HttpClient.iOS.cs
+++ b/Parse/Internal/HttpClient/iOS/HttpClient.iOS.cs
@@ -96,7 +96,7 @@ namespace Parse.Internal {
 
       return uploadTask.Safe().OnSuccess(_ => {
         return request.GetResponseAsync();
-      }).Unwrap().OnSuccess(t => {
+      }).Unwrap().ContinueWith(t => {
         // Handle canceled
         cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Our internal integration tests was broken. This will fix it.

For the case of `HttpClient`, we can't do `OnSuccess`. If you take a look inside the code, we do special handling on error.