### PR TITLE
Use `FromState` instead of `CreateWithoutData` + `HandleFetchResult`

### DIFF
--- a/Parse/Internal/Encoding/ParseDecoder.cs
+++ b/Parse/Internal/Encoding/ParseDecoder.cs
@@ -64,9 +64,8 @@ namespace Parse.Internal {
         }
 
         if (typeString == "Object") {
-          var output = ParseObject.CreateWithoutData(dict["className"] as string, null);
-          output.HandleFetchResult(ParseObjectCoder.Instance.Decode(dict, this));
-          return output;
+          var state = ParseObjectCoder.Instance.Decode(dict, this);
+          return ParseObject.FromState<ParseObject>(state, dict["className"] as string);
         }
 
         if (typeString == "Relation") {

--- a/Parse/Internal/Installation/Controller/ParseCurrentInstallationController.cs
+++ b/Parse/Internal/Installation/Controller/ParseCurrentInstallationController.cs
@@ -70,8 +70,8 @@ namespace Parse.Internal {
           ParseInstallation installation = null;
           if (installationDataString != null) {
             var installationData = ParseClient.DeserializeJsonString(installationDataString);
-            installation = ParseObject.CreateWithoutData<ParseInstallation>(null);
-            installation.HandleFetchResult(ParseObjectCoder.Instance.Decode(installationData, ParseDecoder.Instance));
+            var state = ParseObjectCoder.Instance.Decode(installationData, ParseDecoder.Instance);
+            installation = ParseObject.FromState<ParseInstallation>(state, "_Installation");
           } else {
             installation = ParseObject.Create<ParseInstallation>();
             installation.SetIfDifferent("installationId" , installationIdController.Get().ToString());

--- a/Parse/Internal/User/Controller/ParseCurrentUserController.cs
+++ b/Parse/Internal/User/Controller/ParseCurrentUserController.cs
@@ -67,8 +67,8 @@ namespace Parse.Internal {
           ParseUser user = null;
           if (userDataString != null) {
             var userData =  Json.Parse(userDataString) as IDictionary<string, object>;
-            user = ParseObject.CreateWithoutData<ParseUser>(null);
-            user.HandleFetchResult(ParseObjectCoder.Instance.Decode(userData, ParseDecoder.Instance));
+            var state = ParseObjectCoder.Instance.Decode(userData, ParseDecoder.Instance);
+            user = ParseObject.FromState<ParseUser>(state, "_User");
           }
 
           CurrentUser = user;

--- a/Parse/Public/ParseSession.cs
+++ b/Parse/Public/ParseSession.cs
@@ -67,8 +67,7 @@ namespace Parse {
         }
 
         return SessionController.GetSessionAsync(sessionToken, cancellationToken).OnSuccess(t => {
-          ParseSession session = (ParseSession)ParseObject.CreateWithoutData<ParseSession>(null);
-          session.HandleFetchResult(t.Result);
+          ParseSession session = ParseObject.FromState<ParseSession>(t.Result, "_Session");
           return session;
         });
       }).Unwrap();
@@ -87,8 +86,7 @@ namespace Parse {
       }
 
       return SessionController.UpgradeToRevocableSessionAsync(sessionToken, cancellationToken).OnSuccess(t => {
-        var session = (ParseSession)ParseObject.CreateWithoutData<ParseSession>(null);
-        session.HandleFetchResult(t.Result);
+        ParseSession session = ParseObject.FromState<ParseSession>(t.Result, "_Session");
         return session.SessionToken;
       });
     }

--- a/Parse/Public/ParseUser.cs
+++ b/Parse/Public/ParseUser.cs
@@ -213,8 +213,7 @@ namespace Parse {
         string password,
         CancellationToken cancellationToken) {
       return UserController.LogInAsync(username, password, cancellationToken).OnSuccess(t => {
-        var user = (ParseUser)ParseObject.CreateWithoutData<ParseUser>(null);
-        user.HandleFetchResult(t.Result);
+        ParseUser user = ParseObject.FromState<ParseUser>(t.Result, "_User");
         return SaveCurrentUserAsync(user).OnSuccess(_ => user);
       }).Unwrap();
     }
@@ -238,8 +237,7 @@ namespace Parse {
     /// <returns>The user if authorization was successful</returns>
     public static Task<ParseUser> BecomeAsync(string sessionToken, CancellationToken cancellationToken) {
       return UserController.GetUserAsync(sessionToken, cancellationToken).OnSuccess(t => {
-        var user = (ParseUser)ParseObject.CreateWithoutData<ParseUser>(null);
-        user.HandleFetchResult(t.Result);
+        ParseUser user = ParseObject.FromState<ParseUser>(t.Result, "_User");
         return SaveCurrentUserAsync(user).OnSuccess(_ => user);
       }).Unwrap();
     }
@@ -592,8 +590,7 @@ namespace Parse {
       ParseUser user = null;
 
       return UserController.LogInAsync(authType, data, cancellationToken).OnSuccess(t => {
-        user = (ParseUser)ParseObject.CreateWithoutData<ParseUser>(null);
-        user.HandleFetchResult(t.Result);
+        user = ParseObject.FromState<ParseUser>(t.Result, "_User");
 
         lock (user.mutex) {
           if (user.AuthData == null) {


### PR DESCRIPTION
We have `FromState` which wraps `CreateWithoutData` + `HandleFetchResult`. This is just a convenience method that's also used in Android SDK.

Tested with Unit Test