### PR TITLE
Made TimeZone string generation locale-agnostic for Windows Phone and Unity.

### DIFF
--- a/Parse/Internal/PlatformHooks/Phone/PlatformHooks.Phone.cs
+++ b/Parse/Internal/PlatformHooks/Phone/PlatformHooks.Phone.cs
@@ -150,17 +150,12 @@ namespace Parse {
 
     public string DeviceTimeZone {
       get {
-        // We need the system string to be in english so we'll have the proper key in our lookup table.
-        var culture = Thread.CurrentThread.CurrentCulture;
-        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-        string windowsName = TimeZoneInfo.Local.StandardName;
-        Thread.CurrentThread.CurrentCulture = culture;
-
-        if (ParseInstallation.TimeZoneNameMap.ContainsKey(windowsName)) {
-          return ParseInstallation.TimeZoneNameMap[windowsName];
-        } else {
-          return null;
-        }
+        TimeSpan utcOffset = TimeZoneInfo.Local.BaseUtcOffset;
+        return String.Format("GMT{0}{1}:{2:d2}",
+          offset.TotalSeconds < 0 ? "-" : "+",
+          Math.Abs(offset.Hours),
+          Math.Abs(offset.Minutes)
+        );
       }
     }
 

--- a/Parse/Internal/PlatformHooks/Unity/PlatformHooks.Unity.cs
+++ b/Parse/Internal/PlatformHooks/Unity/PlatformHooks.Unity.cs
@@ -87,16 +87,12 @@ namespace Parse {
 
     public string DeviceTimeZone {
       get {
-        try {
-          string windowsName = TimeZoneInfo.Local.StandardName;
-          if (ParseInstallation.TimeZoneNameMap.ContainsKey(windowsName)) {
-            return ParseInstallation.TimeZoneNameMap[windowsName];
-          } else {
-            return null;
-          }
-        } catch (TimeZoneNotFoundException) {
-          return null;
-        }
+        TimeSpan utcOffset = TimeZoneInfo.Local.BaseUtcOffset;
+        return String.Format("GMT{0}{1}:{2:d2}",
+          offset.TotalSeconds < 0 ? "-" : "+",
+          Math.Abs(offset.Hours),
+          Math.Abs(offset.Minutes)
+        );
       }
     }
 


### PR DESCRIPTION
Previously, TimeZone string generation that we sent along with ParseInstallation was dependent upon the `CurrentCulture` of the device being set to the english locale (as `StandardName` is localized, WHAT?!)

Our new, fancy TimeZone string is now generated agnostically of the current device locale. There is potential for information about the specific region of the time zone to be lost here, but most applications
should not require this.

This should fix #138.