### PR TITLE
Revert "Made TimeZone string generation locale-agnostic for Windows Phone and Unity."

### DIFF
--- a/Parse/Internal/PlatformHooks/Phone/PlatformHooks.Phone.cs
+++ b/Parse/Internal/PlatformHooks/Phone/PlatformHooks.Phone.cs
@@ -150,12 +150,17 @@ namespace Parse {
 
     public string DeviceTimeZone {
       get {
-        TimeSpan utcOffset = TimeZoneInfo.Local.BaseUtcOffset;
-        return String.Format("GMT{0}{1}:{2:d2}",
-          offset.TotalSeconds < 0 ? "-" : "+",
-          Math.Abs(offset.Hours),
-          Math.Abs(offset.Minutes)
-        );
+        // We need the system string to be in english so we'll have the proper key in our lookup table.
+        var culture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        string windowsName = TimeZoneInfo.Local.StandardName;
+        Thread.CurrentThread.CurrentCulture = culture;
+
+        if (ParseInstallation.TimeZoneNameMap.ContainsKey(windowsName)) {
+          return ParseInstallation.TimeZoneNameMap[windowsName];
+        } else {
+          return null;
+        }
       }
     }
 

--- a/Parse/Internal/PlatformHooks/Unity/PlatformHooks.Unity.cs
+++ b/Parse/Internal/PlatformHooks/Unity/PlatformHooks.Unity.cs
@@ -87,12 +87,16 @@ namespace Parse {
 
     public string DeviceTimeZone {
       get {
-        TimeSpan utcOffset = TimeZoneInfo.Local.BaseUtcOffset;
-        return String.Format("GMT{0}{1}:{2:d2}",
-          offset.TotalSeconds < 0 ? "-" : "+",
-          Math.Abs(offset.Hours),
-          Math.Abs(offset.Minutes)
-        );
+        try {
+          string windowsName = TimeZoneInfo.Local.StandardName;
+          if (ParseInstallation.TimeZoneNameMap.ContainsKey(windowsName)) {
+            return ParseInstallation.TimeZoneNameMap[windowsName];
+          } else {
+            return null;
+          }
+        } catch (TimeZoneNotFoundException) {
+          return null;
+        }
       }
     }
 


### PR DESCRIPTION
Reverts ParsePlatform/Parse-SDK-dotNET#145

This fix wasn't working with our backend properly :cry: 