### PR TITLE
Fix TimeZone mappings for Windows Phone and Unity

### DIFF
--- a/Parse/Internal/PlatformHooks/Phone/PlatformHooks.Phone.cs
+++ b/Parse/Internal/PlatformHooks/Phone/PlatformHooks.Phone.cs
@@ -151,16 +151,26 @@ namespace Parse {
     public string DeviceTimeZone {
       get {
         // We need the system string to be in english so we'll have the proper key in our lookup table.
-        var culture = Thread.CurrentThread.CurrentCulture;
-        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-        string windowsName = TimeZoneInfo.Local.StandardName;
-        Thread.CurrentThread.CurrentCulture = culture;
+        // If it's not in english then we will attempt to fallback to the closest Time Zone we can find.
+        TimeZoneInfo tzInfo = TimeZoneInfo.Local;
 
-        if (ParseInstallation.TimeZoneNameMap.ContainsKey(windowsName)) {
-          return ParseInstallation.TimeZoneNameMap[windowsName];
-        } else {
-          return null;
+        string deviceTimeZone = null;
+        if (ParseInstallation.TimeZoneNameMap.TryGetValue(tzInfo.StandardName, out deviceTimeZone)) {
+          return deviceTimeZone;
         }
+
+        TimeSpan utcOffset = tzInfo.BaseUtcOffset;
+
+        // If we have an offset that is not a round hour, then use our second map to see if we can
+        // convert it or not.
+        if (ParseInstallation.TimeZoneOffsetMap.TryGetValue(utcOffset, out deviceTimeZone)) {
+           return deviceTimeZone;
+        }
+
+        // NOTE: Etc/GMT{+/-} format is inverted from the UTC offset we use as normal people -
+        // a negative value means ahead of UTC, a positive value means behind UTC.
+        bool negativeOffset = utcOffset.Ticks < 0;
+        return String.Format("Etc/GMT{0}{1}", negativeOffset ? "+" : "-", Math.Abs(utcOffset.Hours));
       }
     }
 

--- a/Parse/Public/ParseInstallation.cs
+++ b/Parse/Public/ParseInstallation.cs
@@ -352,5 +352,26 @@ namespace Parse {
       {"Tonga Standard Time", "Pacific/Tongatapu"},
       {"Samoa Standard Time", "Pacific/Apia"}
     };
+
+    /// <summary>
+    /// This is a mapping of odd TimeZone offsets to their respective IANA codes across the world.
+    /// This list was compiled from painstakingly pouring over the information available at
+    /// https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+    /// </summary>
+    internal static readonly Dictionary<TimeSpan, String> TimeZoneOffsetMap = new Dictionary<TimeSpan, string>() {
+      { new TimeSpan(12, 45, 0), "Pacific/Chatham" },
+      { new TimeSpan(10, 30, 0), "Australia/Lord_Howe" },
+      { new TimeSpan(9, 30, 0),  "Australia/Adelaide" },
+      { new TimeSpan(8, 45, 0), "Australia/Eucla" },
+      { new TimeSpan(8, 30, 0), "Asia/Pyongyang" }, // Parse in North Korea confirmed.
+      { new TimeSpan(6, 30, 0), "Asia/Rangoon" },
+      { new TimeSpan(5, 45, 0), "Asia/Kathmandu" },
+      { new TimeSpan(5, 30, 0), "Asia/Colombo" },
+      { new TimeSpan(4, 30, 0), "Asia/Kabul" },
+      { new TimeSpan(3, 30, 0), "Asia/Tehran" },
+      { new TimeSpan(-3, 30, 0), "America/St_Johns" },
+      { new TimeSpan(-4, 30, 0), "America/Caracas" },
+      { new TimeSpan(-9, 30, 0), "Pacific/Marquesas" },
+    };
   }
 }


### PR DESCRIPTION
This was causing installation saves to fail when not on english locale.

For real, this time.

Fixes #138.