### PR TITLE
Use the InvariantCulture to format DateTime.

### DIFF
--- a/ParseCore/Internal/Encoding/ParseEncoder.cs
+++ b/ParseCore/Internal/Encoding/ParseEncoder.cs
@@ -40,7 +40,7 @@ namespace Parse.Core.Internal {
       // encoded object. Otherwise, just return the original object.
       if (value is DateTime) {
         return new Dictionary<string, object> {
-          {"iso", ((DateTime)value).ToString(ParseClient.DateFormatStrings.First())},
+          {"iso", ((DateTime)value).ToString(ParseClient.DateFormatStrings.First(), CultureInfo.InvariantCulture)},
           {"__type", "Date"}
         };
       }

--- a/ParseCore/Internal/User/Controller/ParseCurrentUserController.cs
+++ b/ParseCore/Internal/User/Controller/ParseCurrentUserController.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Parse.Common.Internal;
@@ -46,10 +47,12 @@ namespace Parse.Core.Internal {
             var data = user.ServerDataToJSONObjectForSerialization();
             data["objectId"] = user.ObjectId;
             if (user.CreatedAt != null) {
-              data["createdAt"] = user.CreatedAt.Value.ToString(ParseClient.DateFormatStrings.First());
+              data["createdAt"] = user.CreatedAt.Value.ToString(ParseClient.DateFormatStrings.First(),
+                CultureInfo.InvariantCulture);
             }
             if (user.UpdatedAt != null) {
-              data["updatedAt"] = user.UpdatedAt.Value.ToString(ParseClient.DateFormatStrings.First());
+              data["updatedAt"] = user.UpdatedAt.Value.ToString(ParseClient.DateFormatStrings.First(),
+                CultureInfo.InvariantCulture);
             }
 
             saveTask = storageController


### PR DESCRIPTION
This allows dates in Arabic/Thai locales to be entered correctly in parse.