### PR TITLE
fixed URI construction when the server URI included a specific path (http://localhost:1337/parse)

### DIFF
--- a/ParseCore/Internal/Command/ParseCommand.cs
+++ b/ParseCore/Internal/Command/ParseCommand.cs
@@ -46,7 +46,7 @@ namespace Parse.Core.Internal {
         IList<KeyValuePair<string, string>> headers = null,
         Stream stream = null,
         string contentType = null) {
-      Uri = new Uri(new Uri(ParseClient.CurrentConfiguration.Server), relativeUri);
+      Uri = new Uri(new Uri(ParseClient.CurrentConfiguration.Server), ParseClient.CurrentConfiguration.Server.AbsolutePath + "/" + relativeUri);
       Method = method;
       Data = stream;
       Headers = new List<KeyValuePair<string, string>>(headers ?? Enumerable.Empty<KeyValuePair<string, string>>());


### PR DESCRIPTION
this may be needed by setting up a server to use parse on a specific path as follows:

```javascript
var express = require('express');
var ParseServer = require('parse-server').ParseServer;

var config = require('./config.js');

var app = express();
var api = new ParseServer(config.parse);

// Serve the Parse API on the /parse URL prefix
app.use('/parse', api);

app.listen(1337, function() {
  console.log('parse-server-example running on port 1337.');
});
```