### PR TITLE
Fixed minor bug which was causing failing ParseFile uploads.

### DIFF
--- a/ParseCore/Internal/Command/ParseCommand.cs
+++ b/ParseCore/Internal/Command/ParseCommand.cs
@@ -64,6 +64,7 @@ namespace Parse.Core.Internal {
       this.Method = other.Method;
       this.DataObject = other.DataObject;
       this.Headers = new List<KeyValuePair<string, string>>(other.Headers);
+      this.Data = other.Data;
     }
   }
 }


### PR DESCRIPTION
When ParseFile.SaveAsync is called the request will be initially directed to ParseCommandRunner, which will add necessary header attributes and execute the request. RunCommandAsync calls PrepareCommand, which clones the original command into new one
`ParseCommand newCommand = new ParseCommand(command);`

When you go to the implementation of clone constructor you'll see that all fields are cloned, except the Data field, which cause all file uploads fail with "Invalid File upload" message. 