### PR TITLE
ci: Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Set up .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ matrix.DOTNET_VERSION }}
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.nuget/packages
@@ -42,7 +42,7 @@ jobs:
       run: |
         OpenCover.Console.exe -returntargetcode -target:dotnet.exe -targetargs:"test --framework net${{ matrix.DOTNET_VERSION }} --configuration Debug --test-adapter-path:. --logger:console /p:DebugType=full .\Parse.Tests\Parse.Tests.csproj" -filter:"+[Parse*]* -[Parse.Tests*]*" -oldstyle -output:parse_sdk_dotnet_coverage.xml -register:user
     - name: Upload code coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

The `ci` workflow runs several actions still targeting the **Node 20** runtime, which GitHub has deprecated. Every CI run emits:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 ... `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-dotnet@v4` ... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Change

Bump the pinned action majors to the first release that runs on Node 24 (composite for codecov):

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | node24 |
| `actions/setup-dotnet` | v4 | v5 | node24 |
| `actions/cache` | v4 | v5 | node24 |
| `codecov/codecov-action` | v4 | v5 | composite |

All inputs currently used (`dotnet-version`, cache `path`/`key`/`restore-keys`, and codecov `token`/`fail_ci_if_error`) remain supported in v5, so no other changes are needed.

This clears the deprecation warnings and keeps CI working once Node 20 is removed from the runners.
